### PR TITLE
Fix nested f-string quotes causing SyntaxError on Python < 3.12

### DIFF
--- a/webapp/app/apis.py
+++ b/webapp/app/apis.py
@@ -663,7 +663,7 @@ class Api(BaseApi):
         base = os.path.join(
             db.app.config.get("JSON_FOLDER"),
             botinfo.get("JOB_UID")[0],
-            f"{botinfo.get("JOB_UID")}.json",
+            f"{botinfo.get('JOB_UID')}.json",
         )
         with open(base, "w", encoding="utf-8") as f:
             json.dump(json.loads(botinfo.get("RESULT")), f, indent=2)


### PR DESCRIPTION
## Summary

Fixes #84

`apis.py:666` used the same double-quote character inside a double-quoted f-string — a `SyntaxError` on Python ≤ 3.11 (PEP 701 only permits this from 3.12). The entire `apis` module would fail to import on affected versions, breaking all bot endpoints.

## Change

```python
# Before — SyntaxError on Python < 3.12
f"{botinfo.get("JOB_UID")}.json"

# After
f"{botinfo.get('JOB_UID')}.json"
```

## Test plan

- [ ] Confirm `python -c "import webapp.app.apis"` succeeds on Python 3.11
- [ ] Run the full application and verify `/bot_api/sndjob` accepts a valid job submission
