### PR TITLE
Fix KVrocksIndexer constructed with wrong arguments at startup

### DIFF
--- a/webapp/app/scheduler.py
+++ b/webapp/app/scheduler.py
@@ -1498,7 +1498,8 @@ check_json_storage(db.app.config.get("JSON_FOLDER"))
 
 # Connect to the Kvrocks and keep this index for all indexing.
 db.app.config["KVROCKS_IDX"] = KVrocksIndexer(
-    db.app.config.get("KVROCKS_HOST", db.app.config.get("KVROCKS_PORT"))
+    db.app.config.get("KVROCKS_HOST", "localhost"),
+    db.app.config.get("KVROCKS_PORT", 6666),
 )
 
 # Connect to the Mieili DB ( if the index is not present create IT)


### PR DESCRIPTION
## Summary

Fixes #85

`KVrocksIndexer(host, port)` was called with a single argument. When `KVROCKS_HOST` was absent from config, `KVROCKS_PORT` (an integer) became the host string and the port always defaulted to `6666` regardless of config.

## Change

```python
# Before — wrong: one arg, fallback uses PORT as HOST
db.app.config["KVROCKS_IDX"] = KVrocksIndexer(
    db.app.config.get("KVROCKS_HOST", db.app.config.get("KVROCKS_PORT"))
)

# After
db.app.config["KVROCKS_IDX"] = KVrocksIndexer(
    db.app.config.get("KVROCKS_HOST", "localhost"),
    db.app.config.get("KVROCKS_PORT", 6666),
)
```

## Test plan

- [ ] Start the app without `KVROCKS_HOST` in config and verify Kvrocks connects correctly
- [ ] Verify document export and search work end-to-end
