### PR TITLE
Fix thread-unsafe parser config by passing config explicitly

### DIFF
--- a/release_note.md
+++ b/release_note.md
@@ -68,6 +68,7 @@ Changes after `v0.2604.0`.
 - Improve Kvrocks rebuild tooling: direct Meili rebuild, multiprocessing parser workers, retag mode, graceful Ctrl+C, quieter logs, and progress output (`23b9d83`)
 - Split tools Meilisearch config into `IN_MEILI_*` and `OUT_MEILI_*`; remove legacy `MEILI_*` tool config keys (`ef4ceec`)
 - Rework `index_meili.py` to import dumps into `OUT_MEILI_*`, with batching and optional `--progress` (`ef4ceec`)
+- Make result parsing config explicit per call to avoid cross-thread parser state leaks, closes #88
 - Show inserted Tag Rule IDs in `import_tags.py` (`bf1afd5`)
 - Add `import_tags.py --flush-tag` to remove one tag from Kvrocks tag indexes, closes #47
 - Fix `import_tags.py` to update DB tag rules from newer YAML versions and print existing rule IDs, closes #49

--- a/tools/test_result_parser_conf_isolation.py
+++ b/tools/test_result_parser_conf_isolation.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Regression test for concurrent result_parser config isolation.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+import sys
+from pathlib import Path
+from unittest import TestCase, main
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+UTILS_DIR = ROOT_DIR / "webapp" / "app" / "utils"
+sys.path.insert(0, str(UTILS_DIR))
+
+from result_parser import parse_json  # pylint: disable=wrong-import-position
+
+
+def build_document(hostname, headers):
+    """
+    Build a minimal Nmap-like document consumed by parse_json.
+    """
+    return {
+        "id": hostname,
+        "ip": "192.0.2.1",
+        "body": {
+            "endtime": "2026-05-19T00:00:00",
+            "hostnames": [{"name": hostname, "type": "user"}],
+            "ports": [
+                {
+                    "portid": "80",
+                    "scripts": [
+                        {
+                            "id": "http-headers",
+                            "output": headers,
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+
+
+def parse_with_config(hostname, tld, header_name, header_value):
+    """
+    Parse one document with a config unique to this call.
+    """
+    config = {
+        "ONLINETLD": True,
+        "TLDS": [tld],
+        "TLDADD": [],
+        "HTTP_HEADER_COLLECTION": {header_name: True},
+    }
+    document = build_document(
+        hostname,
+        f"{header_name}: {header_value}\nX-Other: ignored\n",
+    )
+    return parse_json(document, config, tag_rules=[])
+
+
+class ResultParserConfigIsolationTest(TestCase):
+    """
+    Verify parser config stays isolated across concurrent calls.
+    """
+
+    def test_concurrent_parse_uses_call_local_config(self):
+        """
+        Concurrent parse_json calls must not share TLD/header config.
+        """
+        cases = [
+            ("alpha.example.com", "example.com", "com", "X-Alpha", "A"),
+            ("beta.example.net", "example.net", "net", "X-Beta", "B"),
+        ]
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = []
+            for case in cases:
+                hostname, _domain, tld, header, value = case
+                for _ in range(50):
+                    futures.append(
+                        (
+                            case,
+                            executor.submit(
+                                parse_with_config, hostname, tld, header, value
+                            ),
+                        )
+                    )
+
+        for case, future in futures:
+            hostname, domain, _tld, header, value = case
+            result = future.result()
+            expected_header = header.lower()
+            self.assertEqual(result["fqdn_requested"], [hostname])
+            self.assertEqual(result["domain_requested"], [domain])
+            self.assertEqual(result["http_header"], [expected_header])
+            self.assertEqual(
+                result["http_headval"], [f"{expected_header}:{value.lower()}"]
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/webapp/app/utils/result_parser.py
+++ b/webapp/app/utils/result_parser.py
@@ -19,6 +19,7 @@ For now far from performance issues anyway.
 """
 
 import re
+import threading
 from pyfaup import Url  # pylint: disable=no-name-in-module
 
 try:
@@ -26,7 +27,11 @@ try:
 except ImportError:
     from tagrules import apply_tag_rules_to_document
 
-DB_CONF = {}
+_thread_local = threading.local()
+
+
+def _get_db_conf():
+    return getattr(_thread_local, "conf", {})
 
 
 def normalize_db_conf(db_conf_local):
@@ -296,14 +301,14 @@ def get_hosts(data: dict, target: str):
                     parse = False
                     if suffix:
                         suffix_str = str(url.suffix).lower()  # TLD
-                        if DB_CONF["ONLINETLD"]:
-                            if suffix_str in DB_CONF["TLDS"]:
+                        if _get_db_conf()["ONLINETLD"]:
+                            if suffix_str in _get_db_conf()["TLDS"]:
                                 parse = True
                         else:
                             if suffix.is_known():
                                 parse = True
 
-                        if suffix_str in DB_CONF["TLDADD"]:
+                        if suffix_str in _get_db_conf()["TLDADD"]:
                             parse = True
 
                     if parse:
@@ -337,14 +342,14 @@ def _parse_valid_hostname(hostname):
 
     suffix_str = str(suffix).lower()
     parse = False
-    if DB_CONF["ONLINETLD"]:
-        if suffix_str in DB_CONF["TLDS"]:
+    if _get_db_conf()["ONLINETLD"]:
+        if suffix_str in _get_db_conf()["TLDS"]:
             parse = True
     else:
         if suffix.is_known():
             parse = True
 
-    if suffix_str in DB_CONF["TLDADD"]:
+    if suffix_str in _get_db_conf()["TLDADD"]:
         parse = True
 
     if not parse:
@@ -470,7 +475,7 @@ def get_http_header(data: dict, target: str):
     Parse configured HTTP header names and selected values.
     """
     body = get_body(data, target)
-    collection = DB_CONF.get("HTTP_HEADER_COLLECTION", {})
+    collection = _get_db_conf().get("HTTP_HEADER_COLLECTION", {})
     http_header = []
     http_headval = []
 
@@ -524,8 +529,7 @@ def parse_json(doc, db_conf_local, tag_rules=None):
     Parse one Nmap-like document into the Kvrocks search fields.
     """
 
-    DB_CONF.clear()
-    DB_CONF.update(normalize_db_conf(db_conf_local))
+    _thread_local.conf = normalize_db_conf(db_conf_local)
 
     final_result = {}  # Parsing result array
     for parsing_rule in default_parsing:

--- a/webapp/app/utils/result_parser.py
+++ b/webapp/app/utils/result_parser.py
@@ -19,19 +19,12 @@ For now far from performance issues anyway.
 """
 
 import re
-import threading
 from pyfaup import Url  # pylint: disable=no-name-in-module
 
 try:
     from .tagrules import apply_tag_rules_to_document
 except ImportError:
     from tagrules import apply_tag_rules_to_document
-
-_thread_local = threading.local()
-
-
-def _get_db_conf():
-    return getattr(_thread_local, "conf", {})
 
 
 def normalize_db_conf(db_conf_local):
@@ -93,6 +86,12 @@ ALLOW = [
     "hsh",
     "get_favicon",
 ]
+
+CONFIG_AWARE_ACTIONS = {
+    "get_fqdn_requested",
+    "get_hosts",
+    "get_http_header",
+}
 
 fqdn_regex = re.compile(
     r"""(?:^|[\s(\/<>|@'"=\:])([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-_]{2,})+)(?=$|[\?\s#&\/<>'",)])""",
@@ -247,6 +246,16 @@ def get_body(data, target):
     return current
 
 
+def run_parser_action(action, script, target, db_conf):
+    """
+    Call one configured parser action with explicit config when required.
+    """
+    parser = globals()[action]
+    if action in CONFIG_AWARE_ACTIONS:
+        return parser(script, target, db_conf)
+    return parser(script, target)
+
+
 def get_http_cookies(data: dict, target: str):
     """
     Get cookies
@@ -281,7 +290,7 @@ def get_http_etag(data: dict, target: str):
     return {"http_etag": http_etag}
 
 
-def get_hosts(data: dict, target: str):
+def get_hosts(data: dict, target: str, db_conf: dict):
     """
     extract fqdn.
     """
@@ -301,14 +310,14 @@ def get_hosts(data: dict, target: str):
                     parse = False
                     if suffix:
                         suffix_str = str(url.suffix).lower()  # TLD
-                        if _get_db_conf()["ONLINETLD"]:
-                            if suffix_str in _get_db_conf()["TLDS"]:
+                        if db_conf["ONLINETLD"]:
+                            if suffix_str in db_conf["TLDS"]:
                                 parse = True
                         else:
                             if suffix.is_known():
                                 parse = True
 
-                        if suffix_str in _get_db_conf()["TLDADD"]:
+                        if suffix_str in db_conf["TLDADD"]:
                             parse = True
 
                     if parse:
@@ -323,7 +332,7 @@ def get_hosts(data: dict, target: str):
     return {"fqdn": fqdn_hosts, "host": hosts, "domain": domains, "tld": tlds}
 
 
-def _parse_valid_hostname(hostname):
+def _parse_valid_hostname(hostname, db_conf: dict):
     """
     Parse one hostname using the configured domain validation rules.
     """
@@ -342,14 +351,14 @@ def _parse_valid_hostname(hostname):
 
     suffix_str = str(suffix).lower()
     parse = False
-    if _get_db_conf()["ONLINETLD"]:
-        if suffix_str in _get_db_conf()["TLDS"]:
+    if db_conf["ONLINETLD"]:
+        if suffix_str in db_conf["TLDS"]:
             parse = True
     else:
         if suffix.is_known():
             parse = True
 
-    if suffix_str in _get_db_conf()["TLDADD"]:
+    if suffix_str in db_conf["TLDADD"]:
         parse = True
 
     if not parse:
@@ -363,7 +372,7 @@ def _parse_valid_hostname(hostname):
     }
 
 
-def get_fqdn_requested(data: dict, target: str):
+def get_fqdn_requested(data: dict, target: str, db_conf: dict):
     """
     Extract user-requested FQDN and domain values from hostnames entries.
     """
@@ -380,7 +389,7 @@ def get_fqdn_requested(data: dict, target: str):
         if hostname and hostname not in fqdn_requested:
             fqdn_requested.append(hostname)
 
-        parsed_hostname = _parse_valid_hostname(hostname)
+        parsed_hostname = _parse_valid_hostname(hostname, db_conf)
         if not parsed_hostname:
             continue
         domain = parsed_hostname.get("domain")
@@ -470,12 +479,12 @@ def get_favicon(data: dict, target: str):
     return result
 
 
-def get_http_header(data: dict, target: str):
+def get_http_header(data: dict, target: str, db_conf: dict):
     """
     Parse configured HTTP header names and selected values.
     """
     body = get_body(data, target)
-    collection = _get_db_conf().get("HTTP_HEADER_COLLECTION", {})
+    collection = db_conf.get("HTTP_HEADER_COLLECTION", {})
     http_header = []
     http_headval = []
 
@@ -529,7 +538,7 @@ def parse_json(doc, db_conf_local, tag_rules=None):
     Parse one Nmap-like document into the Kvrocks search fields.
     """
 
-    _thread_local.conf = normalize_db_conf(db_conf_local)
+    db_conf = normalize_db_conf(db_conf_local)
 
     final_result = {}  # Parsing result array
     for parsing_rule in default_parsing:
@@ -557,17 +566,15 @@ def parse_json(doc, db_conf_local, tag_rules=None):
             for script in doc.get("body"):
                 if script == script_name:  # If it is in the job list.
                     script = doc.get("body").get(script)
-                    parse_result = globals()[action](
-                        script, target
-                    )  # Call the function given in the action variable.
+                    parse_result = run_parser_action(action, script, target, db_conf)
 
         elif section == "p":
             for port in doc.get("body").get("ports"):  # for each ports,
                 for script in port.get("scripts", []):  # We look at script results
                     if script.get("id") == script_name:  # If it is in the job list.
-                        parse_result = globals()[action](
-                            script, target
-                        )  # Call the function given in the action variable.
+                        parse_result = run_parser_action(
+                            action, script, target, db_conf
+                        )
 
         final_result = fuse_dicts(final_result, parse_result)
 


### PR DESCRIPTION
## Summary

Fixes #88

`result_parser.py` used shared parser configuration state across `parse_json` calls. Concurrent scheduler exports and web-request parsing could let TLD/header configuration from one parse affect another.

## Change

- Remove parser config storage from module/thread state
- Normalize config once inside `parse_json`
- Pass `db_conf` explicitly to config-aware helpers (`get_hosts`, `get_fqdn_requested`, `get_http_header`)
- Add `run_parser_action()` so parser dispatch keeps the config boundary explicit
- Add `tools/test_result_parser_conf_isolation.py` covering concurrent parses with different TLD/header configs
- Update `release_note.md`

## Test plan

- [x] `.venv/bin/python tools/test_result_parser_conf_isolation.py`
- [x] `.venv/bin/python -m py_compile webapp/app/utils/result_parser.py tools/test_result_parser_conf_isolation.py`
- [x] `.venv/bin/black webapp/app/utils/result_parser.py tools/test_result_parser_conf_isolation.py`
- [x] `.venv/bin/python tools/test_parse.py tools/meili_dump/4/4b748eff-488c-5b6b-8724-2c0ecccb85d4.json`
- [x] `.venv/bin/pylint --persistent=n webapp/app/utils/result_parser.py tools/test_result_parser_conf_isolation.py` (reports existing refactor warnings in `result_parser.py`: too-many-nested-blocks / too-many-locals)
