### PR TITLE
Fix deprecated flask.Markup import, use markupsafe directly

### DIFF
--- a/webapp/app/models.py
+++ b/webapp/app/models.py
@@ -11,7 +11,7 @@ This is the module containing all the data models
 import html
 import re
 from flask_appbuilder import Model
-from flask import Markup as Esc
+from markupsafe import Markup as Esc
 from sqlalchemy import (
     Column,
     Integer,


### PR DESCRIPTION
## Summary

Fixes #89

`flask.Markup` was deprecated in Flask 2.0 and removed in Flask 3.0. `models.py` still imported from `flask`, while `views.py` already used the correct `from markupsafe import Markup`.

## Change

```python
# Before
from flask import Markup as Esc

# After
from markupsafe import Markup as Esc
```

## Test plan

- [ ] `python -c "from webapp.app.models import Jobs"` succeeds on Flask 3.x
- [ ] All model HTML rendering methods (`job_html`, `tags_html`, etc.) still work in the UI
