### PR TITLE
Replace blocking r.keys() with non-blocking scan_iter in wildcard search fallback

### DIFF
--- a/webapp/app/utils/kvrocks.py
+++ b/webapp/app/utils/kvrocks.py
@@ -618,7 +618,7 @@ class KVrocksIndexer:
                         "No usable criteria get uid list from Base field: %s",
                         base_field,
                     )
-                    matching_keys = self.r.keys(f"{base_field}:*")
+                    matching_keys = list(self.r.scan_iter(match=f"{base_field}:*", count=1000))
                     if not matching_keys:
                         return []
                     partial_result = self.r.sunion(*matching_keys)


### PR DESCRIPTION
## Summary

Fixes #90

The 2A fallback path in `get_uids_by_criteria` (triggered by modifier-only queries like `http_server.like:nginx`) called `self.r.keys(f"{base_field}:*")`. Redis/Kvrocks `KEYS` is O(N) in total key count and blocks the server for its entire duration, stalling concurrent exports, indexation, and searches.

## Change

```python
# Before — blocks the server
matching_keys = self.r.keys(f"{base_field}:*")

# After — non-blocking, consistent with get_indexed_values elsewhere
matching_keys = list(self.r.scan_iter(match=f"{base_field}:*", count=1000))
```

## Test plan

- [ ] Run a modifier-only search query (e.g. `http_server.like:nginx`) and verify results are returned
- [ ] Verify no other operations are blocked during the query
