### PR TITLE
Stop leaking internal exception messages to client in MeiliSearchView.getuid

### DIFF
--- a/webapp/app/views.py
+++ b/webapp/app/views.py
@@ -614,8 +614,9 @@ class MeiliSearchView(BaseView):
         try:
             result = index.get_document(uid)
             return jsonify(vars(result))  # doc is already a dict-like
-        except Exception as e:
-            return jsonify({"error": str(e)}), 404
+        except Exception:
+            logger.exception("Error fetching Meilisearch document uid=%s", uid)
+            return jsonify({"error": "Document not found"}), 404
 
 
 class KVSearchView(BaseView):


### PR DESCRIPTION
## Summary

Fixes #91

The `/meili/getuid` endpoint returned `str(e)` directly to authenticated users, which could expose Meilisearch internal error details, server host/port, or query structure.

## Change

```python
# Before
except Exception as e:
    return jsonify({"error": str(e)}), 404

# After
except Exception:
    logger.exception("Error fetching Meilisearch document uid=%s", uid)
    return jsonify({"error": "Document not found"}), 404
```

## Test plan

- [ ] Request a non-existent document UID and verify the response body is `{"error": "Document not found"}`
- [ ] Verify the server log contains the full exception details
