### PR TITLE
Make root log level configurable via LOG_LEVEL in config

### DIFF
--- a/webapp/app/__init__.py
+++ b/webapp/app/__init__.py
@@ -11,13 +11,16 @@ from sqlalchemy import event
 from sqlalchemy.engine import Engine
 from .security import CustomSecurityManager  # Custom Security menu
 
-# Loggin configuration
-logging.basicConfig(format="%(asctime)s:%(levelname)s:%(name)s:%(message)s")
-logging.getLogger().setLevel(logging.DEBUG)
-
 # Flask + SQLAlchemy
 app = Flask(__name__)
 app.config.from_object("config")
+
+# Logging configuration — level is read from config so production deployments
+# can use WARNING or INFO without patching source code.
+logging.basicConfig(format="%(asctime)s:%(levelname)s:%(name)s:%(message)s")
+_log_level_name = str(app.config.get("LOG_LEVEL", "WARNING")).upper()
+_log_level = getattr(logging, _log_level_name, logging.WARNING)
+logging.getLogger().setLevel(_log_level)
 
 
 @event.listens_for(Engine, "connect")

--- a/webapp/config.py.template
+++ b/webapp/config.py.template
@@ -21,6 +21,9 @@ from flask_appbuilder.security.manager import (
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 
+# Root logging level: DEBUG, INFO, WARNING, ERROR (default WARNING)
+LOG_LEVEL = "WARNING"
+
 # Your App secret key
 SECRET_KEY = "YouNeedToChangeMeInProduction"
 MEILI_KEY = "YouNeedToChangeMeInProduction"


### PR DESCRIPTION
## Summary

Fixes #101

The root logger was hardcoded to `DEBUG` unconditionally at startup. Production deployments had no way to reduce log noise without patching source code. Debug output can also inadvertently log sensitive request payloads.

## Changes

**`webapp/app/__init__.py`**
- Move `basicConfig` after `app.config.from_object("config")` so `LOG_LEVEL` is available from config
- Read the level name from `app.config.get("LOG_LEVEL", "WARNING")` with a safe fallback

**`webapp/config.py.template`**
- Add `LOG_LEVEL = "WARNING"` with a comment explaining the valid values

```python
# Before — hardcoded DEBUG always
logging.getLogger().setLevel(logging.DEBUG)

# After — driven by config, defaults to WARNING
_log_level_name = str(app.config.get("LOG_LEVEL", "WARNING")).upper()
_log_level = getattr(logging, _log_level_name, logging.WARNING)
logging.getLogger().setLevel(_log_level)
```

## Test plan

- [ ] Start app with default `config.py.template` — verify only WARNING+ messages appear in logs
- [ ] Set `LOG_LEVEL = "DEBUG"` in config and restart — verify DEBUG messages appear
- [ ] Set `LOG_LEVEL = "INVALID"` — verify app falls back to WARNING without crashing
