### PR TITLE
Document get_country() as an unimplemented GeoIP stub

### DIFF
--- a/webapp/app/utils/mutils.py
+++ b/webapp/app/utils/mutils.py
@@ -92,8 +92,11 @@ def is_valid_ip_or_cidr(value: str):
 
 def get_country(value):
     """
-    GeoIP
-    #TODO the Code
+    GeoIP lookup stub — always returns the unknown sentinel "WW".
+
+    To implement: integrate a GeoIP library (e.g. geoip2, ip-api, or
+    a MaxMind DB) and resolve the ISO 3166-1 alpha-2 country code from
+    the given public IP address string.
     """
     _ = value
     return "WW"


### PR DESCRIPTION
## Summary

Fixes #103

`get_country()` always returns `"WW"` with only `#TODO the Code` inside its docstring. Every bot beacon registers with a meaningless `"WW"` country in the database, making geographic tracking non-functional. The stub status was not obvious to readers.

## Change

Rewrite the docstring to make the stub explicit and describe what a real implementation would require. No behavior change.

```python
# Before
def get_country(value):
    """
    GeoIP
    #TODO the Code
    """

# After
def get_country(value):
    """
    GeoIP lookup stub — always returns the unknown sentinel "WW".

    To implement: integrate a GeoIP library (e.g. geoip2, ip-api, or
    a MaxMind DB) and resolve the ISO 3166-1 alpha-2 country code from
    the given public IP address string.
    """
```

## Test plan

- [ ] No functional change — existing tests and bot beacon behaviour unchanged
- [ ] A future GeoIP implementation can replace the body without touching callers
