### PR TITLE
feat: add pyproject.toml for PEP 517/518/621 packaging standardization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.backends.legacy:build"
 
 [project]
 name = "plum-island"
-version = "0.1.0"
+version = "0.2604.0"
 description = "Proactive Land Uncovering & Monitoring — network scan orchestration platform"
 readme = "readme.md"
 license = { text = "AGPL-3.0-only" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,75 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.backends.legacy:build"
+
+[project]
+name = "plum-island"
+version = "0.1.0"
+description = "Proactive Land Uncovering & Monitoring — network scan orchestration platform"
+readme = "readme.md"
+license = { text = "AGPL-3.0-only" }
+requires-python = ">=3.11"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: GNU Affero General Public License v3",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Security",
+    "Topic :: System :: Networking :: Monitoring",
+]
+dependencies = [
+    "flask-appbuilder==4.8.1",
+    "flask-Limiter==3.12",
+    "APScheduler>=3.10.0",
+    "netaddr>=0.9.0",
+    "meilisearch>=0.28.0",
+    "redis>=4.6.0",
+    "PyYAML>=6.0",
+    "pyfaup-rs==0.2.0",
+    "pybgpranking2>=0.1",
+    "pyipasnhistory>=0.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+    "ruff>=0.4.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/D4-project/Plum-Island"
+Repository = "https://github.com/D4-project/Plum-Island"
+"Bug Tracker" = "https://github.com/D4-project/Plum-Island/issues"
+
+[tool.setuptools.packages.find]
+where = ["webapp"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 88
+src = ["webapp", "tools"]
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "C4", "PIE", "SIM", "S", "RUF"]
+ignore = ["E501", "B008"]
+
+[tool.ruff.lint.per-file-ignores]
+"webapp/sql_upd/*.py" = ["ALL"]
+"tools/*.py" = ["S", "T201"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "lf"
+
+[tool.pytest.ini_options]
+testpaths = ["tests", "tools"]
+python_files = ["test_*.py"]
+addopts = ["--tb=short", "--strict-markers"]
+markers = [
+    "integration: requires live Kvrocks/Meilisearch",
+    "unit: pure unit tests",
+]


### PR DESCRIPTION
## Summary

- Adds `pyproject.toml` at the project root compliant with PEP 517/518/621
- Consolidates build system, project metadata, and tool configuration in one file
- Mirrors all dependencies from `requirements.txt` with the same pins/bounds established in #108

## Details

### Build system
Uses `setuptools>=68` with the legacy build backend so the existing `webapp/` layout is preserved without restructuring.

### Project metadata
- `name = "plum-island"`, `version = "0.1.0"`, `requires-python = ">=3.11"`
- License: `AGPL-3.0-only`
- Classifiers for Python 3.11/3.12/3.13, Security, Networking/Monitoring categories

### Dependencies
Exact mirror of `requirements.txt` after #108 — `flask-appbuilder==4.8.1`, `flask-Limiter==3.12`, and bounded lower versions for `APScheduler`, `netaddr`, `meilisearch`, `redis`, `PyYAML`, `pybgpranking2`, `pyipasnhistory`. `pyfaup-rs==0.2.0` kept as exact pin.

### Dev extras
`pip install -e ".[dev]"` installs `pytest>=8.0`, `pytest-cov>=5.0`, `ruff>=0.4.0`.

### Ruff configuration
- `target-version = "py311"`, `line-length = 88`
- Lint rules: `E`, `W`, `F`, `I` (isort), `UP` (pyupgrade), `B` (bugbear), `C4`, `PIE`, `SIM`, `S` (bandit), `RUF`
- `webapp/sql_upd/*.py` excluded entirely; `tools/*.py` exempted from `S` and `T201`

### Pytest configuration
- `testpaths = ["tests", "tools"]`
- Markers: `integration` (requires live Kvrocks/Meilisearch), `unit` (pure unit tests)

## Test plan
- [ ] `pip install -e ".[dev]"` installs without errors
- [ ] `ruff check webapp/` runs without configuration errors
- [ ] `pytest --co -q` collects tests without warnings about unknown markers

Closes #109