### PR TITLE
feat: add Dockerfile and docker-compose.yml for containerized deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Copy this file to .env and fill in your values before running docker compose up.
+
+# Required: Meilisearch master key (also used as MEILI_KEY in config.py)
+MEILI_KEY=change_me_in_production
+
+# Flask secret key — auto-generated on first run if left empty
+SECRET_KEY=
+
+# Admin account created on first run
+ADMIN_USER=admin
+ADMIN_EMAIL=admin@plum.local
+# Admin password — auto-generated and printed to logs on first run if left empty
+ADMIN_PASSWORD=
+
+# Optional: CIRCL Passive DNS enrichment credentials
+PASSIVE_USER=
+PASSIVE_PWD=

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 webapp/app.db
 webapp/app/jsons
 webapp/__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.13-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    sqlite3 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /plum
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY webapp/ ./webapp/
+COPY tools/ ./tools/
+COPY nse/ ./nse/
+
+RUN mkdir -p /plum/webapp/app/jsons /plum/webapp/app/export_jobs /plum/data
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+WORKDIR /plum/webapp
+EXPOSE 5000
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
+# Supported release: v0.2604.0
+# Build this image from a checkout of tag v0.2604.0.
+# The main branch requires additional import steps (tag rules, header
+# collection) that are not yet integrated into the Docker setup.
 FROM python:3.13-slim
+
+LABEL org.opencontainers.image.version="0.2604.0" \
+      org.opencontainers.image.source="https://github.com/D4-project/Plum-Island" \
+      org.opencontainers.image.licenses="AGPL-3.0-only"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     sqlite3 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     volumes:
       - meili_data:/meili_data
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:7700/health | grep -q '\"status\":\"available\"'"]
+      test: ["CMD-SHELL", "wget -q -O - http://127.0.0.1:7700/health | grep -q available"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,62 @@
+services:
+  webapp:
+    build: .
+    ports:
+      - "5000:5000"
+    environment:
+      MEILI_KEY: "${MEILI_KEY}"
+      MEILI_DATABASE_URI: "http://meilisearch:7700"
+      KVROCKS_HOST: "kvrocks"
+      KVROCKS_PORT: "6666"
+      SECRET_KEY: "${SECRET_KEY:-}"
+      ADMIN_USER: "${ADMIN_USER:-admin}"
+      ADMIN_EMAIL: "${ADMIN_EMAIL:-admin@plum.local}"
+      ADMIN_PASSWORD: "${ADMIN_PASSWORD:-}"
+      PASSIVE_USER: "${PASSIVE_USER:-}"
+      PASSIVE_PWD: "${PASSIVE_PWD:-}"
+    volumes:
+      - plum_data:/plum/data
+      - plum_jsons:/plum/webapp/app/jsons
+      - plum_exports:/plum/webapp/app/export_jobs
+    depends_on:
+      kvrocks:
+        condition: service_healthy
+      meilisearch:
+        condition: service_healthy
+    restart: unless-stopped
+
+  kvrocks:
+    image: apache/kvrocks:latest
+    ports:
+      - "6666:6666"
+    volumes:
+      - kvrocks_data:/var/lib/kvrocks
+    healthcheck:
+      test: ["CMD-SHELL", "timeout 1 bash -c 'echo > /dev/tcp/localhost/6666'"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  meilisearch:
+    image: getmeili/meilisearch:v1.12
+    ports:
+      - "7700:7700"
+    environment:
+      MEILI_MASTER_KEY: "${MEILI_KEY}"
+      MEILI_ENV: "production"
+    volumes:
+      - meili_data:/meili_data
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:7700/health | grep -q '\"status\":\"available\"'"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  plum_data:
+  plum_jsons:
+  plum_exports:
+  kvrocks_data:
+  meili_data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+CONFIG_FILE="config.py"
+DB_PATH="/plum/data/app.db"
+
+# Generate config.py from environment on first run
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "[plum] Generating config.py from environment..."
+    cp config.py.template "$CONFIG_FILE"
+
+    : "${MEILI_KEY:?MEILI_KEY environment variable is required}"
+    _SECRET="${SECRET_KEY:-$(head -c32 /dev/urandom | base64)}"
+    _MEILI_URI="${MEILI_DATABASE_URI:-http://meilisearch:7700}"
+    _KVROCKS_HOST="${KVROCKS_HOST:-kvrocks}"
+    _KVROCKS_PORT="${KVROCKS_PORT:-6666}"
+
+    sed -i "s|^SECRET_KEY *=.*|SECRET_KEY = \"${_SECRET}\"|" "$CONFIG_FILE"
+    sed -i "s|^MEILI_KEY *=.*|MEILI_KEY = \"${MEILI_KEY}\"|" "$CONFIG_FILE"
+    sed -i "s|^MEILI_DATABASE_URI *=.*|MEILI_DATABASE_URI = \"${_MEILI_URI}\"|" "$CONFIG_FILE"
+    sed -i "s|^KVROCKS_HOST *=.*|KVROCKS_HOST = \"${_KVROCKS_HOST}\"|" "$CONFIG_FILE"
+    sed -i "s|^KVROCKS_PORT *=.*|KVROCKS_PORT = ${_KVROCKS_PORT}|" "$CONFIG_FILE"
+    # Point SQLite at the persistent data volume
+    sed -i "s|^SQLALCHEMY_DATABASE_URI *=.*sqlite.*|SQLALCHEMY_DATABASE_URI = \"sqlite:///${DB_PATH}\"|" "$CONFIG_FILE"
+
+    if [ -n "${PASSIVE_USER:-}" ]; then
+        sed -i "s|^PASSIVE_USER *=.*|PASSIVE_USER = \"${PASSIVE_USER}\"|" "$CONFIG_FILE"
+        sed -i "s|^PASSIVE_PWD *=.*|PASSIVE_PWD = \"${PASSIVE_PWD:-}\"|" "$CONFIG_FILE"
+    fi
+fi
+
+# First-run database initialization
+if [ ! -f "$DB_PATH" ]; then
+    echo "[plum] First run: initializing database..."
+    _ADMIN_PWD="${ADMIN_PASSWORD:-$(head -c16 /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c16)}"
+    flask fab create-admin \
+        --username "${ADMIN_USER:-admin}" \
+        --firstname Admin --lastname Admin \
+        --email "${ADMIN_EMAIL:-admin@plum.local}" \
+        --password "$_ADMIN_PWD"
+    echo "[plum] ================================================="
+    echo "[plum]  Admin user    : ${ADMIN_USER:-admin}"
+    echo "[plum]  Admin password: $_ADMIN_PWD"
+    echo "[plum] ================================================="
+
+    echo "[plum] Loading initial TCP ports, tag rules and NSE scripts..."
+    python ../tools/initial_setup.py
+fi
+
+exec python run.py

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -53,6 +53,85 @@ cd webapp
 python run.py
 ```
 
+## Docker (v0.2604.0)
+
+> **Supported release: v0.2604.0**
+> The `main` branch requires additional import steps not yet integrated into the Docker setup. Always build from the `v0.2604.0` tag.
+
+### Requirements
+
+- Docker Engine 24+
+- Docker Compose v2
+
+### Quick start
+
+```bash
+git clone https://github.com/D4-project/Plum-Island
+cd Plum-Island
+git checkout v0.2604.0
+cp .env.example .env
+```
+
+Edit `.env` and set at minimum:
+
+```
+MEILI_KEY=<a strong random string>
+```
+
+Then start the stack:
+
+```bash
+docker compose up --build
+```
+
+On first run the entrypoint will:
+1. Generate `webapp/config.py` from the environment variables
+2. Create the SQLite database and admin user
+3. Load initial TCP ports, tag rules, and NSE scripts via `tools/initial_setup.py`
+4. Print the admin credentials to stdout — save them before they scroll away
+
+```
+[plum] =================================================
+[plum]  Admin user    : admin
+[plum]  Admin password: <generated>
+[plum] =================================================
+```
+
+The webapp is then reachable at `http://localhost:5000`.
+
+### Configuration
+
+All settings are passed as environment variables (see `.env.example`):
+
+| Variable | Required | Description |
+|---|---|---|
+| `MEILI_KEY` | Yes | Meilisearch master key |
+| `SECRET_KEY` | No | Flask secret key (auto-generated if unset) |
+| `ADMIN_USER` | No | Admin username (default: `admin`) |
+| `ADMIN_EMAIL` | No | Admin email (default: `admin@plum.local`) |
+| `ADMIN_PASSWORD` | No | Admin password (auto-generated if unset) |
+| `PASSIVE_USER` | No | CIRCL Passive DNS username |
+| `PASSIVE_PWD` | No | CIRCL Passive DNS API key |
+
+### Persistence
+
+Data is stored in named Docker volumes that survive container restarts and rebuilds:
+
+| Volume | Contents |
+|---|---|
+| `plum_data` | SQLite database (`app.db`) |
+| `plum_jsons` | Scan result JSON files |
+| `plum_exports` | Async export jobs |
+| `kvrocks_data` | Kvrocks indexed data |
+| `meili_data` | Meilisearch index data |
+
+To stop the stack without losing data:
+
+```bash
+docker compose down        # stops containers, keeps volumes
+docker compose down -v     # stops containers AND deletes all volumes
+```
+
 ## Runtime services
 
 Plum Island expects:


### PR DESCRIPTION
## Summary

- Adds a complete Docker setup targeting release **v0.2604.0**
- All configuration is supplied via environment variables; secrets are never baked into the image
- First-run initialization (DB creation, admin account, initial data) is handled automatically by the entrypoint

> **Supported version: v0.2604.0**
> The `main` branch requires additional import steps (tag rules, header collection list) that are not yet integrated into the Docker entrypoint. Build this image from a checkout of tag `v0.2604.0`.

## Files

| File | Purpose |
|---|---|
| `Dockerfile` | `python:3.13-slim` image; installs `requirements.txt`, copies `webapp/`, `tools/`, `nse/` |
| `docker-entrypoint.sh` | Renders `config.py` from env vars; runs first-run init if no `app.db` exists |
| `docker-compose.yml` | Orchestrates `webapp`, `kvrocks`, `meilisearch` with health checks and named volumes |
| `.env.example` | Documents all required/optional environment variables |
| `.gitignore` | Added `.env` to prevent accidental secret commits |

## Design decisions

**Config from environment** — `docker-entrypoint.sh` renders `config.py` from `config.py.template` using `sed` and env vars. No interactive prompts; consistent with how twelve-factor apps handle configuration.

**Fail-fast on missing `MEILI_KEY`** — uses `${MEILI_KEY:?...}` so the container exits immediately with a clear error if the key is not set. Consistent with the principle expressed in #93: misconfiguration should be loud, not silent.

**First-run initialization** — if `/plum/data/app.db` is absent the entrypoint runs `flask fab create-admin` and `tools/initial_setup.py`, then prints the admin credentials to stdout. Subsequent restarts skip this.

**Named volumes for persistence** — `plum_data` (`app.db`), `plum_jsons` (scan JSON results), `plum_exports` (async export jobs), `kvrocks_data`, `meili_data`. Data survives `docker compose down` and container rebuilds.

**Health checks before webapp starts** — `depends_on` with `condition: service_healthy` ensures Kvrocks and Meilisearch are ready before the Flask app connects.

> **Note on Meilisearch healthcheck**: BusyBox `wget` (used inside the Meilisearch image) resolves `localhost` to `::1` (IPv6) but Meilisearch binds to `0.0.0.0` (IPv4 only). The healthcheck uses `127.0.0.1` explicitly to force IPv4 and avoid a false-unhealthy state.

## Quick start

```bash
git checkout v0.2604.0
cp .env.example .env
# Edit .env: set MEILI_KEY to a strong random string
docker compose up --build
# Admin credentials are printed in the webapp logs on first run
```

## Test plan

- [x] `docker compose up --build` completes without errors
- [x] Webapp reachable at `http://localhost:5000` — HTTP 200
- [x] Admin login works with credentials printed in logs — HTTP 302 redirect to `/`
- [x] `docker compose down && docker compose up` — existing data and login preserved (no re-init, old password accepted)
- [x] Starting without `MEILI_KEY` set prints a clear error and exits — `MEILI_KEY: MEILI_KEY environment variable is required`

Closes #113