### PR TITLE
Fix KVrocksIndexer constructor args at scheduler startup

### DIFF
--- a/webapp/app/scheduler.py
+++ b/webapp/app/scheduler.py
@@ -1608,7 +1608,8 @@ check_json_storage(db.app.config.get("JSON_FOLDER"))
 
 # Connect to the Kvrocks and keep this index for all indexing.
 db.app.config["KVROCKS_IDX"] = KVrocksIndexer(
-    db.app.config.get("KVROCKS_HOST", db.app.config.get("KVROCKS_PORT"))
+    host=db.app.config.get("KVROCKS_HOST", "localhost"),
+    port=db.app.config.get("KVROCKS_PORT", 6666),
 )
 
 # Connect to the Mieili DB ( if the index is not present create IT)


### PR DESCRIPTION
## Summary

Fixes #85.

`KVrocksIndexer(host, port)` was called at module-level scheduler init with a single argument. The second `.get("KVROCKS_PORT")` was the *default fallback for the host argument*, not the port. The port was never passed, defaulting silently to 6666.

## Change

```python
# Before — one arg; port falls back to default 6666
db.app.config["KVROCKS_IDX"] = KVrocksIndexer(
    db.app.config.get("KVROCKS_HOST", db.app.config.get("KVROCKS_PORT"))
)

# After — explicit host and port
db.app.config["KVROCKS_IDX"] = KVrocksIndexer(
    host=db.app.config.get("KVROCKS_HOST", "localhost"),
    port=db.app.config.get("KVROCKS_PORT", 6666),
)
```

Mirrors the already-correct call at line 1383–1384 in the same file.

## Test plan
- [ ] Start the app without `KVROCKS_HOST` in config — verify Kvrocks connects to localhost:6666
- [ ] Start with explicit `KVROCKS_HOST`/`KVROCKS_PORT` — verify both are respected