### PR TITLE
Restore first_seen/last_seen preservation on Kvrocks rebuild

### DIFF
--- a/tools/index_kvrocks.py
+++ b/tools/index_kvrocks.py
@@ -840,11 +840,10 @@ def main():
                 "Meilisearch returned no documents; refusing to rebuild Kvrocks"
             )
 
-    seen_snapshot = (
+    seen_snapshot = None
+    if args.rebuild or args.rebuild_from_meili:
+        seen_snapshot = snapshot_seen_values(indexer)
         rebuild_kvrocks(indexer, include_tags=args.retag)
-        if args.rebuild or args.rebuild_from_meili
-        else None
-    )
 
     if args.rebuild_from_meili:
         source_docs = parsed_documents_from_meili(


### PR DESCRIPTION
## Summary

Fixes #140.

Every `--rebuild` and `--rebuild-from-meili` run was silently discarding all accumulated `first_seen`/`last_seen` history. `rebuild_kvrocks()` always returns `None`; its return value was assigned to `seen_snapshot` and forwarded to `apply_seen_snapshot()`, which bails immediately on a falsy input.

`first_seen` is documented as accumulated Kvrocks state that cannot be reconstructed from Meilisearch alone.

## Change

```python
# Before — rebuild_kvrocks() returns None; snapshot never taken
seen_snapshot = (
    rebuild_kvrocks(indexer, include_tags=args.retag)
    if args.rebuild or args.rebuild_from_meili
    else None
)

# After — snapshot taken before rebuild clears keys
seen_snapshot = None
if args.rebuild or args.rebuild_from_meili:
    seen_snapshot = snapshot_seen_values(indexer)
    rebuild_kvrocks(indexer, include_tags=args.retag)
```

`snapshot_seen_values()` already existed and was used in the pre-v0.2606.0 flow; it was accidentally dropped during the rebuild refactor.

## Test plan
- [ ] Run `--rebuild-from-meili` on a populated index
- [ ] Confirm `first_seen` values survive on a sample of UIDs compared before and after