### PR TITLE
Improve scheduler reliability: isolate step failures, catch Redis errors in export

### DIFF
--- a/webapp/app/scheduler.py
+++ b/webapp/app/scheduler.py
@@ -18,6 +18,7 @@ import meilisearch
 from meilisearch.errors import MeilisearchApiError
 from nmap2json.smarthash import port_smart_hash
 from requests.exceptions import HTTPError
+import redis
 from sqlalchemy import text
 from sqlalchemy.orm import joinedload
 from . import db
@@ -178,7 +179,12 @@ def _run_scheduler_step(step_label, step_func):
     """
     started_at = time.perf_counter()
     logger.info("Scheduler TASK: starting %s", step_label)
-    summary = step_func()
+    try:
+        summary = step_func()
+    except Exception:
+        logger.exception("Scheduler TASK: %s raised an unhandled exception", step_label)
+        elapsed = time.perf_counter() - started_at
+        return {"elapsed": elapsed, "summary": {}, "error": True}
     elapsed = time.perf_counter() - started_at
     summary_text = _format_scheduler_summary(summary)
     if summary_text:
@@ -244,6 +250,9 @@ def task_master_of_puppets():
             step_durations["cleanup_search_sessions"]["elapsed"],
             step_durations["cleanup_export_jobs"]["elapsed"],
         )
+    except Exception:
+        logger.exception("Scheduler TASK: unhandled exception in tick")
+        db.app.config["scheduler_failures"] = db.app.config.get("scheduler_failures", 0) + 1
     finally:
         db.session.remove()
 
@@ -1351,9 +1360,9 @@ def task_export_to_dbs():
             "batches": batch_count,
             "jobs_marked_exported": updated_rows,
         }
-    except (MeilisearchApiError, HTTPError):
+    except (MeilisearchApiError, HTTPError, redis.exceptions.RedisError, OSError, json.JSONDecodeError):
         db.session.rollback()
-        logger.error("Unable to export to Meili database")
+        logger.exception("Unable to export to Meili database")
         return {
             "jobs_scanned": len(job_snapshots),
             "documents_exported": total_documents,


### PR DESCRIPTION
## Summary

Fixes #142. Three related reliability gaps in `scheduler.py`.

## Changes

### 1. Step isolation in `_run_scheduler_step`
A bare `step_func()` call with no error handling meant one failing step silently skipped all remaining steps for the tick (report generation, job cleanup, etc.). Wrapped in `try/except Exception` with `logger.exception` — each step now fails independently.

### 2. Failure tracking in `task_master_of_puppets`
APScheduler silently swallows unhandled tick exceptions. Added an `except Exception` clause that logs with `logger.exception` and increments `db.app.config["scheduler_failures"]`, making scheduler health observable.

### 3. Widen export exception handler
`task_export_to_dbs` only caught `MeilisearchApiError` and `HTTPError`. A Redis error during `flush_batch()` would propagate uncaught, causing a partial Meilisearch write with no Kvrocks update (stores diverge silently). Added `redis.exceptions.RedisError`, `OSError`, and `json.JSONDecodeError` to the except clause. Changed `logger.error` to `logger.exception` to preserve the traceback.

## Test plan
- [ ] Kill Kvrocks during an export tick — verify other tick steps still run and error is logged
- [ ] Verify Meilisearch export error is logged with full traceback (not just the message)
- [ ] Verify `db.app.config["scheduler_failures"]` increments on tick exception