### PR TITLE
Fix kvrocks: raise on not/nt modifier, pipeline smembers to eliminate N+1

### DIFF
--- a/webapp/app/utils/kvrocks.py
+++ b/webapp/app/utils/kvrocks.py
@@ -466,16 +466,27 @@ class KVrocksIndexer:
         if suffix not in ("like", "lk", "begin", "bg"):
             return set()
 
-        matching_uids = set()
         key_prefix = f"http_headval:{header_name}:"
         escaped_prefix = f"http_headval:{self._escape_redis_glob(header_name)}:"
-        for key in self.r.scan_iter(match=f"{escaped_prefix}*"):
+        # Phase 1: collect matching keys (no smembers yet)
+        matching_keys = []
+        for key in self.r.scan_iter(match=f"{escaped_prefix}*", count=1000):
             if not key.startswith(key_prefix):
                 continue
-            indexed_value = key[len(key_prefix) :]
-            if not self._modifier_matches(indexed_value, search_value, suffix):
-                continue
-            key_uids = set(self.r.smembers(key))
+            indexed_value = key[len(key_prefix):]
+            if self._modifier_matches(indexed_value, search_value, suffix):
+                matching_keys.append(key)
+
+        if not matching_keys:
+            return set()
+
+        # Phase 2: batch all smembers in one pipeline
+        pipe = self.r.pipeline(transaction=False)
+        for k in matching_keys:
+            pipe.smembers(k)
+        matching_uids = set()
+        for key_uids_raw in pipe.execute():
+            key_uids = set(key_uids_raw)
             if scoped_uids is not None:
                 key_uids.intersection_update(scoped_uids)
             matching_uids.update(key_uids)
@@ -660,19 +671,23 @@ class KVrocksIndexer:
 
                 # handle .like / .lk / .begin / .bg
                 if suffix in ("like", "lk", "begin", "bg", "not", "nt"):
-                    # substring = value.rstrip("*")
-                    for key in self.r.scan_iter(f"{base_field}:*"):
-                        val = key.split(":", 1)[1]
-                        # If NOT is needed here later, use the already scoped
-                        # partial_result to subtract matching keys instead of
-                        # rescanning every UID value ad hoc.
-                        # IF like or begin we select it.
-                        if (suffix in ("like", "lk") and value in val) or (
-                            suffix in ("begin", "bg") and val.startswith(value)
-                        ):
-                            matching_uids.update(
-                                self.r.smembers(key).intersection(partial_result)
-                            )
+                    if suffix in ("not", "nt"):
+                        raise ValueError(
+                            f"not/nt modifier is not yet implemented for Kvrocks queries (field={field!r})"
+                        )
+                    # Phase 1: collect matching keys (no smembers yet)
+                    matching_keys = [
+                        key
+                        for key in self.r.scan_iter(f"{base_field}:*", count=1000)
+                        if self._modifier_matches(key.split(":", 1)[1], value, suffix)
+                    ]
+                    # Phase 2: batch all smembers in one pipeline
+                    if matching_keys:
+                        pipe = self.r.pipeline(transaction=False)
+                        for k in matching_keys:
+                            pipe.smembers(k)
+                        for members in pipe.execute():
+                            matching_uids.update(members.intersection(partial_result))
                     partial_result = partial_result.intersection(matching_uids)
                 else:
                     # exact match
@@ -733,14 +748,23 @@ class KVrocksIndexer:
                         )
                     )
                 elif suffix in ("like", "lk", "begin", "bg", "not", "nt"):
-                    for key in self.r.scan_iter(f"{base_field}:*"):
-                        val = key.split(":", 1)[1]
-                        if (suffix in ("like", "lk") and value in val) or (
-                            suffix in ("begin", "bg") and val.startswith(value)
-                        ):
-                            value_uids.update(
-                                self.r.smembers(key).intersection(partial_result)
-                            )
+                    if suffix in ("not", "nt"):
+                        raise ValueError(
+                            f"not/nt modifier is not yet implemented for Kvrocks queries (field={field!r})"
+                        )
+                    # Phase 1: collect matching keys (no smembers yet)
+                    matching_keys = [
+                        key
+                        for key in self.r.scan_iter(f"{base_field}:*", count=1000)
+                        if self._modifier_matches(key.split(":", 1)[1], value, suffix)
+                    ]
+                    # Phase 2: batch all smembers in one pipeline
+                    if matching_keys:
+                        pipe = self.r.pipeline(transaction=False)
+                        for k in matching_keys:
+                            pipe.smembers(k)
+                        for members in pipe.execute():
+                            value_uids.update(members.intersection(partial_result))
                 else:
                     value_uids.update(
                         self.r.smembers(f"{base_field}:{value}").intersection(


### PR DESCRIPTION
## Summary

Fixes #144. Two bugs in `kvrocks.py` related to the v0.2606.0 `scan_iter` refactor (which fixed the `r.keys()` blocking from #90).

## Changes

### 1. `not`/`nt` modifier raises ValueError instead of silently returning empty
`"not"` and `"nt"` were listed in the suffix guard but had no implementation. Any `field.not:value` query silently returned zero results. Now raises `ValueError("not/nt modifier is not yet implemented...")` to give callers a clear signal.

### 2. Pipeline `smembers` calls — eliminates N+1 Redis round trips
The `like`/`begin` scan_iter loops issued one `self.r.smembers(key)` per matching key — potentially thousands of serial Redis round trips per search. Replaced with a two-phase approach: collect matching keys first (via scan_iter), then issue all smembers in a single pipeline. Same fix applied to `_get_uids_for_http_headval`.

### 3. Shared `_suffix_matches` helper
The existing `_modifier_matches` static method already handles the `like`/`begin` condition. The scan_iter loops in `get_uids_by_criteria` and `get_uids_by_criteria_scoped` now reuse `_modifier_matches` directly, eliminating the duplicated inline conditionals.

### 4. Added missing `count=1000` hint on scan_iter calls
Two calls were missing the hint that all other scan_iter call sites use.

## Relation to #90
The `r.keys()` blocking was fixed in v0.2606.0. This PR fixes the N+1 pattern in the replacement scan_iter loops.

## Test plan
- [ ] A `field.not:value` query now raises `ValueError` (not silent empty result)
- [ ] A `field.like:value` query with many matching keys issues a single Redis pipeline instead of N round trips
- [ ] Search results are identical to the pre-fix behaviour for `like` and `begin` queries