### PR TITLE
Auth hardening: timing oracle, priority race, bot ownership, rate limiting

### DIFF
--- a/webapp/app/__init__.py
+++ b/webapp/app/__init__.py
@@ -49,6 +49,16 @@ prepare_export_jobs_folder(app.config["EXPORT_JOBS_FOLDER"])
 db = SQLA(app)
 appbuilder = AppBuilder(app, db.session, security_manager_class=CustomSecurityManager)
 
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+limiter = Limiter(
+    get_remote_address,
+    app=app,
+    default_limits=["500/hour"],
+    storage_uri="memory://",
+)
+
 # Import views and APIs
 # pylint: disable=C0413
 from . import views

--- a/webapp/app/apis.py
+++ b/webapp/app/apis.py
@@ -12,6 +12,7 @@ import base64
 import os
 import json
 import logging
+import threading
 import time
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder import ModelRestApi, has_access
@@ -119,8 +120,12 @@ class BotInfoSchema(Schema):
             )
             if check_password_hash(agentkey, value):
                 return True  # If the key is existing
-        except NoResultFound as error:
-            raise ValidationError("Invalid AGENT_KEY") from error
+        except NoResultFound:
+            # Dummy comparison to prevent timing oracle on key index existence
+            check_password_hash(
+                "pbkdf2:sha256:260000$plum_timing_dummy$" + "a" * 64, value
+            )
+            raise ValidationError("Invalid AGENT_KEY")
         raise ValidationError("Invalid AGENT_KEY")
 
 
@@ -259,41 +264,45 @@ def _get_available_job_priorities():
     return priorities
 
 
+_priority_lock = threading.Lock()
+
+
 def _select_weighted_priority(available_priorities):
     """
     Smooth weighted round-robin over currently non-empty priority queues.
     """
-    available_priorities = set(available_priorities or [])
-    if not available_priorities:
-        return []
+    with _priority_lock:
+        available_priorities = set(available_priorities or [])
+        if not available_priorities:
+            return []
 
-    state = db.app.config.setdefault(
-        "priority_weighted_round_robin",
-        {priority: 0 for priority in PRIORITY_WEIGHTS},
-    )
-    for priority in PRIORITY_WEIGHTS:
-        state.setdefault(priority, 0)
-        if priority not in available_priorities:
-            state[priority] = 0
+        state = db.app.config.setdefault(
+            "priority_weighted_round_robin",
+            {priority: 0 for priority in PRIORITY_WEIGHTS},
+        )
+        for priority in PRIORITY_WEIGHTS:
+            state.setdefault(priority, 0)
+            if priority not in available_priorities:
+                state[priority] = 0
 
-    total_weight = 0
-    for priority in sorted(available_priorities, reverse=True):
-        weight = PRIORITY_WEIGHTS[priority]
-        state[priority] += weight
-        total_weight += weight
+        total_weight = 0
+        for priority in sorted(available_priorities, reverse=True):
+            weight = PRIORITY_WEIGHTS[priority]
+            state[priority] += weight
+            total_weight += weight
 
-    selected_priority = max(
-        available_priorities,
-        key=lambda priority: (state[priority], priority),
-    )
-    state[selected_priority] -= total_weight
-    db.app.config["priority_weighted_round_robin"] = state
+        selected_priority = max(
+            available_priorities,
+            key=lambda priority: (state[priority], priority),
+        )
+        state[selected_priority] -= total_weight
+        db.app.config["priority_weighted_round_robin"] = state
 
-    fallback_priorities = sorted(
-        available_priorities - {selected_priority},
-        reverse=True,
-    )
-    return [selected_priority] + fallback_priorities
+        fallback_priorities = sorted(
+            available_priorities - {selected_priority},
+            reverse=True,
+        )
+        return [selected_priority] + fallback_priorities
 
 
 class PublicTargetsApi(ModelRestApi):
@@ -605,11 +614,18 @@ class Api(BaseApi):
             return self.response(404, message="job not found")
 
         if job_bot.finished and not job_bot.active:
+            if job_bot.bot_id != submitting_bot.id:
+                logger.warning(
+                    "Bot %s tried to submit already-completed job %s owned by bot_id %s",
+                    botinfo.get("UID"),
+                    job_bot.uid,
+                    job_bot.bot_id,
+                )
+                return self.response(403, message="forbidden")
             logger.info(
-                "Bot %s resubmitted already completed job %s assigned to bot_id %s; returning idempotent success",
+                "Bot %s resubmitted already completed job %s; returning idempotent success",
                 botinfo.get("UID"),
                 job_bot.uid,
-                job_bot.bot_id,
             )
             submitting_bot.running = False
             submitting_bot.last_seen = utcnow_naive()


### PR DESCRIPTION
## Summary

Fixes #143. Four auth and access-control gaps in the bot API.

**Note:** This PR touches `apis.py` which was also changed in PR #154 (payload hardening). Merge PR #154 first and rebase this branch before merging.

## Changes

### 1. Timing oracle on key validation (`apis.py`)
`validate_agent_key` returned immediately without running `check_password_hash` when the key index was not found. Valid key prefixes were enumerable via response timing (scrypt/pbkdf2 is slow, so a found-but-wrong-password key takes measurably longer than an unknown prefix). Added a dummy hash comparison in the `NoResultFound` path to normalize timing.

### 2. Thread-safe priority scheduler (`apis.py`)
`_select_weighted_priority` read-modify-wrote `db.app.config["priority_weighted_round_robin"]` without a lock. Under multi-threaded WSGI, concurrent `getjob` requests could corrupt the fairness counters. Added `threading.Lock()` wrapping the full function body.

### 3. Bot ownership before idempotency (`apis.py`)
The idempotency return (200 for re-submitted completed jobs) fired before the ownership check. Any authenticated bot could probe finished job UIDs and receive 200, harvesting `bot_id` values from log output. Moved ownership check to fire first — non-owner gets 403.

### 4. Flask-Limiter wired up (`__init__.py`)
`flask-Limiter` was declared in `requirements.txt` but never instantiated. All bot API endpoints were unrate-limited. Added `Limiter` initialization with `memory://` storage and `500/hour` default. Per-endpoint limits for `getjob`/`sndjob` require a follow-up (Flask-AppBuilder class-based views need custom integration).

## Test plan
- [ ] Key with valid 16-char prefix but wrong password — response time should be similar to unknown prefix
- [ ] Two concurrent getjob requests — verify priority counters are consistent
- [ ] Bot B submits completed job owned by Bot A — verify 403
- [ ] Rate limiter active — verify 429 after 500 requests/hour