### PR TITLE
Fix kvrocks: pipeline smembers to eliminate N+1 Redis round trips

### DIFF
--- a/webapp/app/utils/kvrocks.py
+++ b/webapp/app/utils/kvrocks.py
@@ -469,16 +469,21 @@ class KVrocksIndexer:
         matching_uids = set()
         key_prefix = f"http_headval:{header_name}:"
         escaped_prefix = f"http_headval:{self._escape_redis_glob(header_name)}:"
-        for key in self.r.scan_iter(match=f"{escaped_prefix}*"):
-            if not key.startswith(key_prefix):
-                continue
-            indexed_value = key[len(key_prefix) :]
-            if not self._modifier_matches(indexed_value, search_value, suffix):
-                continue
-            key_uids = set(self.r.smembers(key))
-            if scoped_uids is not None:
-                key_uids.intersection_update(scoped_uids)
-            matching_uids.update(key_uids)
+        matching_keys = [
+            key
+            for key in self.r.scan_iter(match=f"{escaped_prefix}*", count=1000)
+            if key.startswith(key_prefix)
+            and self._modifier_matches(key[len(key_prefix) :], search_value, suffix)
+        ]
+        if matching_keys:
+            pipe = self.r.pipeline(transaction=False)
+            for k in matching_keys:
+                pipe.smembers(k)
+            for members in pipe.execute():
+                key_uids = set(members)
+                if scoped_uids is not None:
+                    key_uids.intersection_update(scoped_uids)
+                matching_uids.update(key_uids)
         return matching_uids
 
     def get_uids_by_criteria(self, criteria: dict):
@@ -660,19 +665,20 @@ class KVrocksIndexer:
 
                 # handle .like / .lk / .begin / .bg
                 if suffix in ("like", "lk", "begin", "bg", "not", "nt"):
-                    # substring = value.rstrip("*")
-                    for key in self.r.scan_iter(f"{base_field}:*"):
-                        val = key.split(":", 1)[1]
-                        # If NOT is needed here later, use the already scoped
-                        # partial_result to subtract matching keys instead of
-                        # rescanning every UID value ad hoc.
-                        # IF like or begin we select it.
-                        if (suffix in ("like", "lk") and value in val) or (
-                            suffix in ("begin", "bg") and val.startswith(value)
-                        ):
-                            matching_uids.update(
-                                self.r.smembers(key).intersection(partial_result)
-                            )
+                    # If NOT is needed here later, use the already scoped
+                    # partial_result to subtract matching keys instead of
+                    # rescanning every UID value ad hoc.
+                    matching_keys = [
+                        key
+                        for key in self.r.scan_iter(f"{base_field}:*", count=1000)
+                        if self._modifier_matches(key.split(":", 1)[1], suffix, value)
+                    ]
+                    if matching_keys:
+                        pipe = self.r.pipeline(transaction=False)
+                        for k in matching_keys:
+                            pipe.smembers(k)
+                        for members in pipe.execute():
+                            matching_uids.update(set(members).intersection(partial_result))
                     partial_result = partial_result.intersection(matching_uids)
                 else:
                     # exact match
@@ -733,14 +739,17 @@ class KVrocksIndexer:
                         )
                     )
                 elif suffix in ("like", "lk", "begin", "bg", "not", "nt"):
-                    for key in self.r.scan_iter(f"{base_field}:*"):
-                        val = key.split(":", 1)[1]
-                        if (suffix in ("like", "lk") and value in val) or (
-                            suffix in ("begin", "bg") and val.startswith(value)
-                        ):
-                            value_uids.update(
-                                self.r.smembers(key).intersection(partial_result)
-                            )
+                    matching_keys = [
+                        key
+                        for key in self.r.scan_iter(f"{base_field}:*", count=1000)
+                        if self._modifier_matches(key.split(":", 1)[1], suffix, value)
+                    ]
+                    if matching_keys:
+                        pipe = self.r.pipeline(transaction=False)
+                        for k in matching_keys:
+                            pipe.smembers(k)
+                        for members in pipe.execute():
+                            value_uids.update(set(members).intersection(partial_result))
                 else:
                     value_uids.update(
                         self.r.smembers(f"{base_field}:{value}").intersection(


### PR DESCRIPTION
## Summary

Follow-up to the closed PR #155. The `not`/`nt` modifier change has been dropped per maintainer feedback — that is intentional and will be addressed in a future parenthesis/syntax refactor.

This PR contains only the N+1 fix, which is independent of the modifier work.

## Problem

In `get_uids_by_criteria`, `get_uids_by_criteria_scoped`, and `_get_uids_for_http_headval`, the `scan_iter` loops issued one synchronous `self.r.smembers(key)` call per matching key. On a large index, a `field.like:value` query could produce thousands of serial Redis round trips in a single search request.

## Change

Two-phase approach in all three methods:
1. Collect all matching keys from `scan_iter` (key filtering only, no data reads)
2. Issue all `smembers` calls in a single `pipeline(transaction=False)` batch

```python
# Before — N+1 round trips
for key in self.r.scan_iter(f"{base_field}:*"):
    if matches(key):
        matching_uids.update(self.r.smembers(key).intersection(partial_result))

# After — 1 pipeline per query
matching_keys = [k for k in self.r.scan_iter(f"{base_field}:*", count=1000) if matches(k)]
if matching_keys:
    pipe = self.r.pipeline(transaction=False)
    for k in matching_keys: pipe.smembers(k)
    for members in pipe.execute():
        matching_uids.update(set(members).intersection(partial_result))
```

Also adds the missing `count=1000` hint to the two `scan_iter` calls that were omitted.

## Test plan
- [ ] A `field.like:value` query returns the same results as before
- [ ] A `field.begin:value` query returns the same results as before
- [ ] Redis monitor shows a single PIPELINE batch instead of N individual SMEMBERS commands