### PR TITLE
Fix sndjob: write result file before marking job finished

### DIFF
--- a/webapp/app/apis.py
+++ b/webapp/app/apis.py
@@ -658,16 +658,26 @@ class Api(BaseApi):
         # Write the result file BEFORE mutating ORM state.
         # If the write fails (disk full, OSError, malformed JSON), the job
         # must not be marked finished — the agent can retry and resubmit.
+        result_payload = botinfo.get("RESULT")
+        if result_payload is None:
+            logger.warning(
+                "Bot %s submitted job %s without RESULT payload",
+                botinfo.get("UID"),
+                botinfo.get("JOB_UID"),
+            )
+            db.session.rollback()
+            return self.response(400, message="missing result")
+
         base = os.path.join(
             db.app.config.get("JSON_FOLDER"),
             botinfo.get("JOB_UID")[0],
             f"{botinfo.get('JOB_UID')}.json",
         )
         try:
-            result_data = json.loads(botinfo.get("RESULT"))
+            result_data = json.loads(result_payload)
             with open(base, "w", encoding="utf-8") as f:
                 json.dump(result_data, f, indent=2)
-        except (OSError, json.JSONDecodeError) as exc:
+        except (OSError, TypeError, json.JSONDecodeError):
             logger.exception(
                 "Failed to write result file for job %s", botinfo.get("JOB_UID")
             )

--- a/webapp/app/apis.py
+++ b/webapp/app/apis.py
@@ -655,21 +655,30 @@ class Api(BaseApi):
             )
             return self.response(429, message="job submitted too quickly")
 
-        job_bot.finished = True
-        job_bot.active = False
-        job_bot.job_end = now
-        submitting_bot.running = False
-        submitting_bot.last_seen = now
-
-        # Save the Job
-        # Build path
+        # Write the result file BEFORE mutating ORM state.
+        # If the write fails (disk full, OSError, malformed JSON), the job
+        # must not be marked finished — the agent can retry and resubmit.
         base = os.path.join(
             db.app.config.get("JSON_FOLDER"),
             botinfo.get("JOB_UID")[0],
             f"{botinfo.get('JOB_UID')}.json",
         )
-        with open(base, "w", encoding="utf-8") as f:
-            json.dump(json.loads(botinfo.get("RESULT")), f, indent=2)
+        try:
+            result_data = json.loads(botinfo.get("RESULT"))
+            with open(base, "w", encoding="utf-8") as f:
+                json.dump(result_data, f, indent=2)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.exception(
+                "Failed to write result file for job %s", botinfo.get("JOB_UID")
+            )
+            db.session.rollback()
+            return self.response(500, message="result storage failed")
+
+        job_bot.finished = True
+        job_bot.active = False
+        job_bot.job_end = now
+        submitting_bot.running = False
+        submitting_bot.last_seen = now
 
         logger.debug("job_bot: %s", job_bot)
         # Check if we release the Target as Ready for a new Turn


### PR DESCRIPTION
## Summary

Scoped-down version of the reliability concern from #141 — no payload size cap, just the file write ordering fix.

## Problem

In `sndjob`, `job_bot.finished = True` was set **before** `open(base, "w")`. If the write failed (disk full, `OSError`, malformed `RESULT` JSON), the ORM state was already mutated. The next `db.session.commit()` would persist a "finished" job with no file on disk. The agent's retry then hit the idempotent guard and received a silent 200 — the scan result was permanently lost with no log entry identifying the cause.

## Change

Move the file write before the ORM mutations. Wrap it in `try/except (OSError, json.JSONDecodeError)`:
- On failure: `db.session.rollback()` + return 500 → agent can retry cleanly
- On success: ORM is mutated as before

```python
# Before — ORM mutated first, file write after
job_bot.finished = True
...
with open(base, "w") as f:
    json.dump(json.loads(botinfo.get("RESULT")), f)

# After — file write first, ORM only on success
try:
    result_data = json.loads(botinfo.get("RESULT"))
    with open(base, "w", encoding="utf-8") as f:
        json.dump(result_data, f, indent=2)
except (OSError, json.JSONDecodeError) as exc:
    logger.exception("Failed to write result file for job %s", ...)
    db.session.rollback()
    return self.response(500, message="result storage failed")

job_bot.finished = True
...
```

## Test plan
- [ ] Normal submission — job marked finished, file written as before
- [ ] Simulate `OSError` during write — job NOT marked finished, agent retry succeeds