### PR TITLE
fix: align run.py port with docker-compose.yml

### DIFF
--- a/webapp/run.py
+++ b/webapp/run.py
@@ -1,3 +1,3 @@
 from app import app
 
-app.run(host="0.0.0.0", port=5001, debug=True)
+app.run(host="0.0.0.0", port=5000, debug=True)


### PR DESCRIPTION
## Summary

- `webapp/run.py` was starting Flask on port **5001** while `docker-compose.yml` maps `5000:5000` and the `Dockerfile` declares `EXPOSE 5000`
- This made the webapp container unreachable on port 5000 in any Docker Compose deployment
- Fix: change `run.py` to bind on port 5000

Fixes #163

## Test plan

- [ ] `docker compose up -d` starts all containers
- [ ] `curl http://localhost:5000/` returns HTTP 200