### PR TITLE
Add plum_net external network for Plum-Agent connectivity

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,9 @@ services:
       meilisearch:
         condition: service_healthy
     restart: unless-stopped
+    networks:
+      - default
+      - plum_net
 
   kvrocks:
     image: apache/kvrocks:latest
@@ -60,3 +63,7 @@ volumes:
   plum_exports:
   kvrocks_data:
   meili_data:
+
+networks:
+  plum_net:
+    external: true

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -130,6 +130,36 @@ docker compose down        # stops containers, keeps volumes
 docker compose down -v     # stops containers AND deletes all volumes
 ```
 
+### Connecting Plum-Agent
+
+Plum-Agent runs as a separate Docker Compose stack. Because each stack gets its own isolated bridge network by default, the agent container cannot reach the Island `webapp` service unless they share an external network.
+
+**One-time setup — create the shared network on the host:**
+
+```bash
+docker network create plum_net
+```
+
+This is already declared as an external network in Plum-Island's `docker-compose.yml`. The `webapp` service joins it automatically when the stack starts. Only `webapp` is exposed on `plum_net`; `kvrocks` and `meilisearch` remain on the internal stack network.
+
+**In the Plum-Agent stack**, set the Island URL to the `webapp` service name:
+
+```bash
+PLUM_ISLAND=http://webapp:5000
+```
+
+Start both stacks (order does not matter):
+
+```bash
+# Plum-Island directory
+docker compose up -d
+
+# Plum-Agent directory
+docker compose up -d
+```
+
+See the [Plum-Agent repository](https://github.com/D4-project/Plum-Agent) for agent installation and configuration.
+
 ## Runtime services
 
 Plum Island expects:

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -142,10 +142,10 @@ docker network create plum_net
 
 This is already declared as an external network in Plum-Island's `docker-compose.yml`. The `webapp` service joins it automatically when the stack starts. Only `webapp` is exposed on `plum_net`; `kvrocks` and `meilisearch` remain on the internal stack network.
 
-**In the Plum-Agent stack**, set the Island URL to the `webapp` service name:
+**In the Plum-Agent stack**, set the Island URL to the `plum-webapp` service name:
 
 ```bash
-PLUM_ISLAND=http://webapp:5000
+PLUM_ISLAND=http://plum-webapp:5000
 ```
 
 Start both stacks (order does not matter):


### PR DESCRIPTION
## Problem

When Plum-Island and Plum-Agent are deployed as separate Docker Compose stacks, each stack gets its own isolated bridge network. The agent container cannot reach the Island `webapp` service because they have no network in common, resulting in:

```
ERROR  HTTPConnectionPool(host='127.0.0.1', port=5000): Max retries exceeded
       with url: /bot_api/beacon (Caused by NewConnectionError(...
       Failed to establish a new connection: [Errno 111] Connection refused))
```

## Changes

- **`docker-compose.yml`** — `webapp` service joins an external Docker network `plum_net` in addition to the default internal network. `kvrocks` and `meilisearch` are not exposed on `plum_net` — only the bot-facing webapp needs to be reachable by agents.
- **`documentation/installation.md`** — new *Connecting Plum-Agent* subsection in the Docker section explaining the one-time `docker network create plum_net` step, the `PLUM_ISLAND=http://webapp:5000` setting, and how to start both stacks.

## Setup

Create the shared network once on the host before starting either stack:

```bash
docker network create plum_net
```

The companion change for Plum-Agent is in [D4-project/Plum-Agent#7](https://github.com/D4-project/Plum-Agent/pull/7).
With both changes applied, set `PLUM_ISLAND=http://webapp:5000` in the agent's `.env` file.

## Test plan

- [ ] `docker network create plum_net` then `docker compose up -d` in both repos — agent beacons successfully to Island
- [ ] `kvrocks` and `meilisearch` are not reachable from the agent container (only `webapp` is on `plum_net`)
- [ ] `documentation/installation.md` Docker section contains the *Connecting Plum-Agent* subsection