### PR TITLE
Rename Docker Compose services with plum- prefix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
-  webapp:
+  plum-webapp:
     build: .
     ports:
       - "5000:5000"
     environment:
       MEILI_KEY: "${MEILI_KEY}"
-      MEILI_DATABASE_URI: "http://meilisearch:7700"
-      KVROCKS_HOST: "kvrocks"
+      MEILI_DATABASE_URI: "http://plum-meilisearch:7700"
+      KVROCKS_HOST: "plum-kvrocks"
       KVROCKS_PORT: "6666"
       SECRET_KEY: "${SECRET_KEY:-}"
       ADMIN_USER: "${ADMIN_USER:-admin}"
@@ -19,13 +19,13 @@ services:
       - plum_jsons:/plum/webapp/app/jsons
       - plum_exports:/plum/webapp/app/export_jobs
     depends_on:
-      kvrocks:
+      plum-kvrocks:
         condition: service_healthy
-      meilisearch:
+      plum-meilisearch:
         condition: service_healthy
     restart: unless-stopped
 
-  kvrocks:
+  plum-kvrocks:
     image: apache/kvrocks:latest
     ports:
       - "6666:6666"
@@ -38,7 +38,7 @@ services:
       retries: 10
     restart: unless-stopped
 
-  meilisearch:
+  plum-meilisearch:
     image: getmeili/meilisearch:v1.22.2
     ports:
       - "7700:7700"


### PR DESCRIPTION
## Summary

Rename all three Docker Compose services to use a consistent `plum-` prefix, making container names unambiguous on hosts running multiple stacks.

| Before | After |
|--------|-------|
| `webapp` | `plum-webapp` |
| `kvrocks` | `plum-kvrocks` |
| `meilisearch` | `plum-meilisearch` |

Internal service references were updated in the same commit:
- `MEILI_DATABASE_URI`: `http://meilisearch:7700` → `http://plum-meilisearch:7700`
- `KVROCKS_HOST`: `kvrocks` → `plum-kvrocks`
- `depends_on`: `meilisearch` → `plum-meilisearch`

## Test plan

- [ ] `docker compose up -d` starts all three containers without errors
- [ ] `plum-webapp` can reach `plum-kvrocks` and `plum-meilisearch` (check startup logs for no connection errors)
- [ ] `docker ps` shows containers named `plum-island-plum-webapp-1`, `plum-island-plum-kvrocks-1`, `plum-island-plum-meilisearch-1`