### PR TITLE
fix: Docker port mismatch prevents agent connectivity

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,8 +11,8 @@ if [ ! -f "$CONFIG_FILE" ]; then
 
     : "${MEILI_KEY:?MEILI_KEY environment variable is required}"
     _SECRET="${SECRET_KEY:-$(head -c32 /dev/urandom | base64)}"
-    _MEILI_URI="${MEILI_DATABASE_URI:-http://meilisearch:7700}"
-    _KVROCKS_HOST="${KVROCKS_HOST:-kvrocks}"
+    _MEILI_URI="${MEILI_DATABASE_URI:-http://plum-meilisearch:7700}"
+    _KVROCKS_HOST="${KVROCKS_HOST:-plum-kvrocks}"
     _KVROCKS_PORT="${KVROCKS_PORT:-6666}"
 
     sed -i "s|^SECRET_KEY *=.*|SECRET_KEY = \"${_SECRET}\"|" "$CONFIG_FILE"

--- a/webapp/run.py
+++ b/webapp/run.py
@@ -1,3 +1,3 @@
 from app import app
 
-app.run(host="0.0.0.0", port=5001, debug=True)
+app.run(host="0.0.0.0", port=5000, debug=True)


### PR DESCRIPTION
## Problem

`webapp/run.py` binds Flask to port **5001** but `docker-compose.yml` maps `5000:5000`. Nothing listens on port 5000 inside the container, so any connection to `http://plum-webapp:5000` (from an agent or a browser via the host mapping) gets an immediate `Connection refused`:

```
ERROR  HTTPConnectionPool(host='plum-webapp', port=5000): Max retries exceeded
       with url: /bot_api/beacon (Caused by NewConnectionError(
       Failed to establish a new connection: [Errno 111] Connection refused))
```

Additionally, the fallback service names in `docker-entrypoint.sh` still referenced the old names (`meilisearch`, `kvrocks`) that were renamed to `plum-meilisearch` and `plum-kvrocks`.

## Changes

- **`webapp/run.py`** — `port=5001` → `port=5000`, aligning the Flask bind port with the `docker-compose.yml` port mapping.
- **`docker-entrypoint.sh`** — fallback defaults updated: `http://meilisearch:7700` → `http://plum-meilisearch:7700` and `kvrocks` → `plum-kvrocks`.

## Test plan

- [ ] `docker compose up -d --build` — `plum-webapp` starts and listens on port 5000
- [ ] `curl http://localhost:5000` from the host returns the Plum-Island login page
- [ ] A Plum-Agent container on `plum_net` successfully beacons to `http://plum-webapp:5000/bot_api/beacon`