### PR TITLE
fix: persist NSE uploads across container rebuilds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - plum_data:/plum/data
       - plum_jsons:/plum/webapp/app/jsons
       - plum_exports:/plum/webapp/app/export_jobs
+      - plum_uploads:/plum/webapp/app/static/uploads
     depends_on:
       kvrocks:
         condition: service_healthy
@@ -58,5 +59,6 @@ volumes:
   plum_data:
   plum_jsons:
   plum_exports:
+  plum_uploads:
   kvrocks_data:
   meili_data:


### PR DESCRIPTION
## Problem

`/plum/webapp/app/static/uploads/` stores NSE script files written by `initial_setup.py` and via the admin UI. This path was not mounted as a Docker volume, so the files were lost on every container rebuild (`docker compose up --build`).

After a rebuild the database still references the old NSE file paths, causing every `GET /bot_api/getjob` to return **400** with:

```
FileNotFoundError: [Errno 2] No such file or directory:
  '/plum/webapp/app/static/uploads/initial_setup__<hash>__banner.nse'
```

## Fix

Mount the uploads directory as a named Docker volume (`plum_uploads`) so NSE files survive container rebuilds.

```yaml
- plum_uploads:/plum/webapp/app/static/uploads
```

## Migration note

Existing deployments that hit this issue should do a full reset to let `initial_setup.py` repopulate the DB and write fresh NSE files into the new volume:

```bash
docker compose down -v
docker compose up -d --build
```

## Test plan

- [ ] Fresh `docker compose up -d --build` — `initial_setup.py` writes NSE files into `plum_uploads`
- [ ] `docker compose up -d --build` (rebuild without `-v`) — NSE files are still present, agents receive jobs successfully
- [ ] `docker volume ls` shows `plum-island_plum_uploads`