### PR TITLE
feat(api): add NsesApi — REST CRUD endpoints for NSE script management

### DIFF
--- a/release_note.md
+++ b/release_note.md
@@ -14,6 +14,7 @@
   - Fix `tag_mgmt.py` flush-tag key corruption, zero-selector handling, datetime sentinel, and interrupted import STOP_REQUESTED reset, closes #150.
   - Clean up interrupted Meilisearch import indexes.
 - Webapp fixes and hardening:
+  - Add authenticated REST CRUD API for NSE script management with OpenAPI documentation, closes #172.
   - Write bot job result files before marking jobs finished, closes #162.
   - Harden `/bot_api/sndjob` result parsing failures.
   - Align `webapp/run.py` port with `docker-compose.yml`, closes #164.

--- a/test/test_api_marshmallow_validators.py
+++ b/test/test_api_marshmallow_validators.py
@@ -3,6 +3,8 @@
 Regression tests for API Marshmallow validators.
 """
 
+# pylint: disable=protected-access
+
 import os
 import sys
 from unittest import TestCase, main
@@ -12,7 +14,7 @@ from marshmallow import ValidationError
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.join(BASE_DIR, "webapp"))
 
-from app.apis import BotInfoSchema  # pylint: disable=wrong-import-position
+from app.apis import BotInfoSchema, NsesApi  # pylint: disable=wrong-import-position
 
 
 class BotInfoSchemaValidationTest(TestCase):
@@ -31,6 +33,31 @@ class BotInfoSchemaValidationTest(TestCase):
             BotInfoSchema().load({"JOB_UID": "bad"}, partial=True)
 
         self.assertEqual(context.exception.messages, {"JOB_UID": ["Invalid JOB_UID"]})
+
+
+class NsesApiValidationTest(TestCase):
+    """Tests for NSE API input normalization helpers."""
+
+    def test_normalize_nse_name_strips_paths(self):
+        """Path-like names must not be stored verbatim."""
+        self.assertEqual(
+            NsesApi._normalize_nse_name("../../script.nse"),
+            "script.nse",
+        )
+
+    def test_normalize_nse_name_appends_suffix_for_form_names(self):
+        """PUT rename accepts bare names and normalizes to .nse."""
+        self.assertEqual(
+            NsesApi._normalize_nse_name("script", append_suffix=True),
+            "script.nse",
+        )
+
+    def test_normalize_nse_name_rejects_empty_name(self):
+        """Blank or suffix-only names are invalid."""
+        for value in ("", "   ", ".nse"):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    NsesApi._normalize_nse_name(value, append_suffix=True)
 
 
 if __name__ == "__main__":

--- a/webapp/app/apis.py
+++ b/webapp/app/apis.py
@@ -8,6 +8,8 @@
 This module contains all code related to API's.
 """
 
+# pylint: disable=too-many-lines
+
 import base64
 import hashlib
 import os
@@ -15,10 +17,9 @@ import json
 import logging
 import time
 from flask_appbuilder.models.sqla.interface import SQLAInterface
-from flask_appbuilder import ModelRestApi, has_access
-from flask_appbuilder.api import BaseApi, expose, safe, protect
-from flask_appbuilder.filemanager import FileManager
+from flask_appbuilder import ModelRestApi
 from flask_appbuilder.api import API_RESULT_RES_KEY, BaseApi, expose, safe, protect
+from flask_appbuilder.filemanager import FileManager
 from flask import request
 
 from sqlalchemy import func, distinct
@@ -830,44 +831,101 @@ class NsesApi(BaseApi):
     """
     REST API for managing NSE (Nmap Script Engine) scripts.
 
-    Provides programmatic equivalents of the /nsesview HTML form: list, create,
-    and delete NSE entries.  File upload uses multipart/form-data; all other
-    responses are JSON.
+    Provides programmatic equivalents of the /nsesview HTML form. File upload
+    uses multipart/form-data; all other responses are JSON.
     """
 
     route_base = "/api/v1/nses"
     openapi_spec_tag = "NSE Scripts API"
+
+    @staticmethod
+    def _serialize_nse(item):
+        return {"id": item.id, "name": item.name, "hash": item.hash}
+
+    @staticmethod
+    def _normalize_nse_name(value, append_suffix=False):
+        raw_name = (value or "").strip()
+        if not raw_name:
+            raise ValueError("NSE script name cannot be empty")
+
+        name = os.path.basename(raw_name)
+        if not name or name in {".", ".."}:
+            raise ValueError("NSE script name cannot be empty")
+
+        if append_suffix and not name.lower().endswith(".nse"):
+            name = f"{name}.nse"
+
+        if name.lower() == ".nse":
+            raise ValueError("NSE script name cannot be empty")
+
+        if not name.lower().endswith(".nse"):
+            raise ValueError("Only .nse files are allowed")
+
+        return name
+
+    @classmethod
+    def _upload_metadata(cls, upload):
+        if upload is None or not getattr(upload, "filename", ""):
+            raise ValueError("Field 'filebody' with a .nse file is required")
+
+        filename = cls._normalize_nse_name(upload.filename)
+        file_bytes = upload.read()
+        upload.stream.seek(0)
+        return filename, hashlib.sha256(file_bytes).hexdigest()
+
+    @staticmethod
+    def _delete_uploaded_file(file_manager, file_name):
+        if not file_name:
+            return
+        try:
+            file_manager.delete_file(file_name)
+        except OSError:
+            logger.exception("Failed to delete NSE upload file %s", file_name)
+
+    @staticmethod
+    def _save_uploaded_file(file_manager, item, upload):
+        stored_name = file_manager.generate_name(item, upload)
+        return file_manager.save_file(upload, stored_name)
+
+    @staticmethod
+    def _duplicate_value_response():
+        return BaseApi.response(
+            400,
+            message="An NSE script with this name or SHA256 already exists",
+        )
 
     @expose("/", methods=["GET"])
     @protect()
     @safe
     def list(self):
         """
-        summary: List all NSE scripts.
-        responses:
-            200:
-                description: Array of NSE script metadata objects.
-                content:
-                    application/json:
-                        schema:
-                            type: object
-                            properties:
-                                result:
-                                    type: array
-                                    items:
-                                        type: object
-                                        properties:
-                                            id:
-                                                type: integer
-                                            name:
-                                                type: string
-                                            hash:
-                                                type: string
+        ---
+        get:
+          summary: List all NSE scripts.
+          responses:
+            "200":
+              description: Array of NSE script metadata objects.
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      result:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                            name:
+                              type: string
+                            hash:
+                              type: string
         """
         nses = db.session.query(Nses).order_by(Nses.name.asc()).all()
         return self.response(
             200,
-            result=[{"id": n.id, "name": n.name, "hash": n.hash} for n in nses],
+            result=[self._serialize_nse(item) for item in nses],
         )
 
     @expose("/", methods=["POST"])
@@ -875,40 +933,49 @@ class NsesApi(BaseApi):
     @safe
     def create(self):
         """
-        summary: Upload a new NSE script.
-        description: |
+        ---
+        post:
+          summary: Upload a new NSE script.
+          description: |
             Accepts a multipart/form-data request with a single field named
             ``filebody`` containing the .nse file.  The filename must end in
             ``.nse``; the stored script name is derived from the uploaded
             filename (not a separate form field).  If an entry with the same
             name already exists it is updated in-place; duplicate SHA256 hashes
             are rejected.
-        parameters:
-            - in: formData
-              name: filebody
-              required: true
-              type: file
-              description: The .nse script file to upload.
-        responses:
-            201:
-                description: NSE script created or updated successfully.
-            400:
-                description: Missing file, wrong extension, or duplicate hash.
+          requestBody:
+            required: true
+            content:
+              multipart/form-data:
+                schema:
+                  type: object
+                  required:
+                    - filebody
+                  properties:
+                    filebody:
+                      type: string
+                      format: binary
+                      description: The .nse script file to upload.
+          responses:
+            "200":
+              description: Existing NSE script updated successfully.
+            "201":
+              description: NSE script created successfully.
+            "400":
+              description: Missing file, wrong extension, or duplicate hash.
         """
         upload = request.files.get("filebody")
-        if not upload or not getattr(upload, "filename", ""):
-            return self.response_400(message="Field 'filebody' with a .nse file is required")
+        try:
+            filename, sha256sum = self._upload_metadata(upload)
+        except ValueError as error:
+            return self.response_400(message=str(error))
 
-        filename = os.path.basename(upload.filename)
-        if not filename.lower().endswith(".nse"):
-            return self.response_400(message="Only .nse files are allowed")
-
-        file_bytes = upload.read()
-        upload.stream.seek(0)
-        sha256sum = hashlib.sha256(file_bytes).hexdigest()
-
-        existing_by_hash = db.session.query(Nses).filter(Nses.hash == sha256sum).one_or_none()
-        existing_by_name = db.session.query(Nses).filter(Nses.name == filename).one_or_none()
+        existing_by_hash = (
+            db.session.query(Nses).filter(Nses.hash == sha256sum).one_or_none()
+        )
+        existing_by_name = (
+            db.session.query(Nses).filter(Nses.name == filename).one_or_none()
+        )
 
         if existing_by_hash is not None and (
             existing_by_name is None or existing_by_name.id != existing_by_hash.id
@@ -919,29 +986,36 @@ class NsesApi(BaseApi):
 
         file_manager = FileManager()
         item = existing_by_name
+        old_filebody = item.filebody if item is not None else None
+        new_filebody = None
 
         if item is not None:
-            # Update: replace file on disk and refresh hash.
-            if item.filebody:
-                file_manager.delete_file(item.filebody)
-            stored_name = file_manager.generate_name(item, upload)
-            item.filebody = file_manager.save_file(upload, stored_name)
+            new_filebody = self._save_uploaded_file(file_manager, item, upload)
+            item.filebody = new_filebody
             item.hash = sha256sum
-            db.session.commit()
             status = 200
         else:
             item = Nses()
             item.name = filename
             item.hash = sha256sum
-            stored_name = file_manager.generate_name(item, upload)
-            item.filebody = file_manager.save_file(upload, stored_name)
+            new_filebody = self._save_uploaded_file(file_manager, item, upload)
+            item.filebody = new_filebody
             db.session.add(item)
-            db.session.commit()
             status = 201
+
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            self._delete_uploaded_file(file_manager, new_filebody)
+            return self._duplicate_value_response()
+
+        if old_filebody and old_filebody != new_filebody:
+            self._delete_uploaded_file(file_manager, old_filebody)
 
         return self.response(
             status,
-            result={"id": item.id, "name": item.name, "hash": item.hash},
+            result=self._serialize_nse(item),
         )
 
     @expose("/<int:pk>", methods=["GET"])
@@ -949,137 +1023,188 @@ class NsesApi(BaseApi):
     @safe
     def get(self, pk):
         """
-        summary: Get a single NSE script by ID.
-        parameters:
+        ---
+        get:
+          summary: Get a single NSE script by ID.
+          parameters:
             - in: path
               name: pk
               required: true
               schema:
-                  type: integer
-        responses:
-            200:
-                description: NSE script metadata.
-            404:
-                description: NSE script not found.
+                type: integer
+          responses:
+            "200":
+              description: NSE script metadata.
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      result:
+                        type: object
+                        properties:
+                          id:
+                            type: integer
+                          name:
+                            type: string
+                          hash:
+                            type: string
+            "404":
+              description: NSE script not found.
         """
         item = db.session.query(Nses).filter(Nses.id == pk).one_or_none()
         if item is None:
             return self.response_404()
-        return self.response(200, result={"id": item.id, "name": item.name, "hash": item.hash})
+        return self.response(200, result=self._serialize_nse(item))
 
     @expose("/<int:pk>", methods=["PUT"])
     @protect()
     @safe
     def update(self, pk):
         """
-        summary: Update an NSE script by ID.
-        description: |
+        ---
+        put:
+          summary: Update an NSE script by ID.
+          description: |
             Replace the file content (``filebody``) and/or rename (``name`` form
             field) an existing NSE script.  At least one must be supplied.
             Duplicate SHA256 hashes and name collisions with other records are
             rejected.
-        parameters:
+          parameters:
             - in: path
               name: pk
               required: true
               schema:
-                  type: integer
-            - in: formData
-              name: filebody
-              required: false
-              type: file
-              description: New .nse script file.
-            - in: formData
-              name: name
-              required: false
-              type: string
-              description: New script name (must end in .nse; suffix appended if omitted).
-        responses:
-            200:
-                description: NSE script updated successfully.
-            400:
-                description: Missing payload, wrong extension, duplicate hash, or name collision.
-            404:
-                description: NSE script not found.
+                type: integer
+          requestBody:
+            required: true
+            content:
+              multipart/form-data:
+                schema:
+                  type: object
+                  properties:
+                    filebody:
+                      type: string
+                      format: binary
+                      description: New .nse script file.
+                    name:
+                      type: string
+                      description: New script name; .nse suffix is appended if omitted.
+          responses:
+            "200":
+              description: NSE script updated successfully.
+            "400":
+              description: Missing payload, wrong extension, duplicate hash, or name collision.
+            "404":
+              description: NSE script not found.
         """
         item = db.session.query(Nses).filter(Nses.id == pk).one_or_none()
         if item is None:
             return self.response_404()
 
         upload = request.files.get("filebody")
-        new_name = request.form.get("name")
+        has_upload_field = upload is not None
+        has_name_field = "name" in request.form
+        new_name = None
 
-        if not upload and not new_name:
-            return self.response_400(message="Provide at least a new 'filebody' or a new 'name'")
-
-        if upload and getattr(upload, "filename", ""):
-            filename = os.path.basename(upload.filename)
-            if not filename.lower().endswith(".nse"):
-                return self.response_400(message="Only .nse files are allowed")
-            file_bytes = upload.read()
-            upload.stream.seek(0)
-            sha256sum = hashlib.sha256(file_bytes).hexdigest()
-            collision = (
-                db.session.query(Nses)
-                .filter(Nses.hash == sha256sum, Nses.id != pk)
-                .one_or_none()
+        if not has_upload_field and not has_name_field:
+            return self.response_400(
+                message="Provide at least a new 'filebody' or a new 'name'"
             )
-            if collision is not None:
-                return self.response_400(
-                    message="An NSE script with this file content (SHA256) already exists under a different name"
+
+        try:
+            if has_name_field:
+                new_name = self._normalize_nse_name(
+                    request.form.get("name"),
+                    append_suffix=True,
                 )
-            file_manager = FileManager()
-            if item.filebody:
-                file_manager.delete_file(item.filebody)
-            stored_name = file_manager.generate_name(item, upload)
-            item.filebody = file_manager.save_file(upload, stored_name)
+
+                collision = (
+                    db.session.query(Nses)
+                    .filter(Nses.name == new_name, Nses.id != pk)
+                    .one_or_none()
+                )
+                if collision is not None:
+                    raise ValueError(f"An NSE script named '{new_name}' already exists")
+
+            if has_upload_field:
+                _, sha256sum = self._upload_metadata(upload)
+
+                collision = (
+                    db.session.query(Nses)
+                    .filter(Nses.hash == sha256sum, Nses.id != pk)
+                    .one_or_none()
+                )
+                if collision is not None:
+                    raise ValueError(
+                        "An NSE script with this file content (SHA256) already exists "
+                        "under a different name"
+                    )
+        except ValueError as error:
+            return self.response_400(message=str(error))
+
+        file_manager = FileManager()
+        old_filebody = item.filebody
+        new_filebody = None
+
+        if has_upload_field:
+            new_filebody = self._save_uploaded_file(file_manager, item, upload)
+            item.filebody = new_filebody
             item.hash = sha256sum
 
-        if new_name:
-            if not new_name.lower().endswith(".nse"):
-                new_name = f"{new_name}.nse"
-            collision = (
-                db.session.query(Nses)
-                .filter(Nses.name == new_name, Nses.id != pk)
-                .one_or_none()
-            )
-            if collision is not None:
-                return self.response_400(message=f"An NSE script named '{new_name}' already exists")
+        if new_name is not None:
             item.name = new_name
 
-        db.session.commit()
-        return self.response(200, result={"id": item.id, "name": item.name, "hash": item.hash})
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            self._delete_uploaded_file(file_manager, new_filebody)
+            return self._duplicate_value_response()
+
+        if old_filebody and new_filebody and old_filebody != new_filebody:
+            self._delete_uploaded_file(file_manager, old_filebody)
+
+        return self.response(200, result=self._serialize_nse(item))
 
     @expose("/<int:pk>", methods=["DELETE"])
     @protect()
     @safe
     def delete(self, pk):
         """
-        summary: Delete an NSE script by ID.
-        parameters:
+        ---
+        delete:
+          summary: Delete an NSE script by ID.
+          parameters:
             - in: path
               name: pk
               required: true
               schema:
-                  type: integer
+                type: integer
               description: ID of the NSE script to delete.
-        responses:
-            200:
-                description: NSE script deleted successfully.
-            404:
-                description: NSE script not found.
+          responses:
+            "200":
+              description: NSE script deleted successfully.
+            "404":
+              description: NSE script not found.
         """
         item = db.session.query(Nses).filter(Nses.id == pk).one_or_none()
         if item is None:
             return self.response_404()
 
         file_manager = FileManager()
-        if item.filebody:
-            file_manager.delete_file(item.filebody)
+        old_filebody = item.filebody
+        item_name = item.name
 
         db.session.delete(item)
-        db.session.commit()
-        return self.response(200, message=f"NSE '{item.name}' deleted")
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            return self._duplicate_value_response()
+
+        self._delete_uploaded_file(file_manager, old_filebody)
+        return self.response(200, message=f"NSE '{item_name}' deleted")
 
 
 appbuilder.add_api(PublicTargetsApi)

--- a/webapp/app/apis.py
+++ b/webapp/app/apis.py
@@ -9,6 +9,7 @@ This module contains all code related to API's.
 """
 
 import base64
+import hashlib
 import os
 import json
 import logging
@@ -16,6 +17,7 @@ import time
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder import ModelRestApi, has_access
 from flask_appbuilder.api import BaseApi, expose, safe, protect
+from flask_appbuilder.filemanager import FileManager
 from flask import request
 
 from sqlalchemy import func, distinct
@@ -761,6 +763,263 @@ class Api(BaseApi):
         return self.response(200, message="ready")
 
 
+class NsesApi(BaseApi):
+    """
+    REST API for managing NSE (Nmap Script Engine) scripts.
+
+    Provides programmatic equivalents of the /nsesview HTML form: list, create,
+    and delete NSE entries.  File upload uses multipart/form-data; all other
+    responses are JSON.
+    """
+
+    route_base = "/api/v1/nses"
+    openapi_spec_tag = "NSE Scripts API"
+
+    @expose("/", methods=["GET"])
+    @protect()
+    @safe
+    def list(self):
+        """
+        summary: List all NSE scripts.
+        responses:
+            200:
+                description: Array of NSE script metadata objects.
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                result:
+                                    type: array
+                                    items:
+                                        type: object
+                                        properties:
+                                            id:
+                                                type: integer
+                                            name:
+                                                type: string
+                                            hash:
+                                                type: string
+        """
+        nses = db.session.query(Nses).order_by(Nses.name.asc()).all()
+        return self.response(
+            200,
+            result=[{"id": n.id, "name": n.name, "hash": n.hash} for n in nses],
+        )
+
+    @expose("/", methods=["POST"])
+    @protect()
+    @safe
+    def create(self):
+        """
+        summary: Upload a new NSE script.
+        description: |
+            Accepts a multipart/form-data request with a single field named
+            ``filebody`` containing the .nse file.  The filename must end in
+            ``.nse``; the stored script name is derived from the uploaded
+            filename (not a separate form field).  If an entry with the same
+            name already exists it is updated in-place; duplicate SHA256 hashes
+            are rejected.
+        parameters:
+            - in: formData
+              name: filebody
+              required: true
+              type: file
+              description: The .nse script file to upload.
+        responses:
+            201:
+                description: NSE script created or updated successfully.
+            400:
+                description: Missing file, wrong extension, or duplicate hash.
+        """
+        upload = request.files.get("filebody")
+        if not upload or not getattr(upload, "filename", ""):
+            return self.response_400(message="Field 'filebody' with a .nse file is required")
+
+        filename = os.path.basename(upload.filename)
+        if not filename.lower().endswith(".nse"):
+            return self.response_400(message="Only .nse files are allowed")
+
+        file_bytes = upload.read()
+        upload.stream.seek(0)
+        sha256sum = hashlib.sha256(file_bytes).hexdigest()
+
+        existing_by_hash = db.session.query(Nses).filter(Nses.hash == sha256sum).one_or_none()
+        existing_by_name = db.session.query(Nses).filter(Nses.name == filename).one_or_none()
+
+        if existing_by_hash is not None and (
+            existing_by_name is None or existing_by_name.id != existing_by_hash.id
+        ):
+            return self.response_400(
+                message="An NSE script with this file content (SHA256) already exists under a different name"
+            )
+
+        file_manager = FileManager()
+        item = existing_by_name
+
+        if item is not None:
+            # Update: replace file on disk and refresh hash.
+            if item.filebody:
+                file_manager.delete_file(item.filebody)
+            stored_name = file_manager.generate_name(item, upload)
+            item.filebody = file_manager.save_file(upload, stored_name)
+            item.hash = sha256sum
+            db.session.commit()
+            status = 200
+        else:
+            item = Nses()
+            item.name = filename
+            item.hash = sha256sum
+            stored_name = file_manager.generate_name(item, upload)
+            item.filebody = file_manager.save_file(upload, stored_name)
+            db.session.add(item)
+            db.session.commit()
+            status = 201
+
+        return self.response(
+            status,
+            result={"id": item.id, "name": item.name, "hash": item.hash},
+        )
+
+    @expose("/<int:pk>", methods=["GET"])
+    @protect()
+    @safe
+    def get(self, pk):
+        """
+        summary: Get a single NSE script by ID.
+        parameters:
+            - in: path
+              name: pk
+              required: true
+              schema:
+                  type: integer
+        responses:
+            200:
+                description: NSE script metadata.
+            404:
+                description: NSE script not found.
+        """
+        item = db.session.query(Nses).filter(Nses.id == pk).one_or_none()
+        if item is None:
+            return self.response_404()
+        return self.response(200, result={"id": item.id, "name": item.name, "hash": item.hash})
+
+    @expose("/<int:pk>", methods=["PUT"])
+    @protect()
+    @safe
+    def update(self, pk):
+        """
+        summary: Update an NSE script by ID.
+        description: |
+            Replace the file content (``filebody``) and/or rename (``name`` form
+            field) an existing NSE script.  At least one must be supplied.
+            Duplicate SHA256 hashes and name collisions with other records are
+            rejected.
+        parameters:
+            - in: path
+              name: pk
+              required: true
+              schema:
+                  type: integer
+            - in: formData
+              name: filebody
+              required: false
+              type: file
+              description: New .nse script file.
+            - in: formData
+              name: name
+              required: false
+              type: string
+              description: New script name (must end in .nse; suffix appended if omitted).
+        responses:
+            200:
+                description: NSE script updated successfully.
+            400:
+                description: Missing payload, wrong extension, duplicate hash, or name collision.
+            404:
+                description: NSE script not found.
+        """
+        item = db.session.query(Nses).filter(Nses.id == pk).one_or_none()
+        if item is None:
+            return self.response_404()
+
+        upload = request.files.get("filebody")
+        new_name = request.form.get("name")
+
+        if not upload and not new_name:
+            return self.response_400(message="Provide at least a new 'filebody' or a new 'name'")
+
+        if upload and getattr(upload, "filename", ""):
+            filename = os.path.basename(upload.filename)
+            if not filename.lower().endswith(".nse"):
+                return self.response_400(message="Only .nse files are allowed")
+            file_bytes = upload.read()
+            upload.stream.seek(0)
+            sha256sum = hashlib.sha256(file_bytes).hexdigest()
+            collision = (
+                db.session.query(Nses)
+                .filter(Nses.hash == sha256sum, Nses.id != pk)
+                .one_or_none()
+            )
+            if collision is not None:
+                return self.response_400(
+                    message="An NSE script with this file content (SHA256) already exists under a different name"
+                )
+            file_manager = FileManager()
+            if item.filebody:
+                file_manager.delete_file(item.filebody)
+            stored_name = file_manager.generate_name(item, upload)
+            item.filebody = file_manager.save_file(upload, stored_name)
+            item.hash = sha256sum
+
+        if new_name:
+            if not new_name.lower().endswith(".nse"):
+                new_name = f"{new_name}.nse"
+            collision = (
+                db.session.query(Nses)
+                .filter(Nses.name == new_name, Nses.id != pk)
+                .one_or_none()
+            )
+            if collision is not None:
+                return self.response_400(message=f"An NSE script named '{new_name}' already exists")
+            item.name = new_name
+
+        db.session.commit()
+        return self.response(200, result={"id": item.id, "name": item.name, "hash": item.hash})
+
+    @expose("/<int:pk>", methods=["DELETE"])
+    @protect()
+    @safe
+    def delete(self, pk):
+        """
+        summary: Delete an NSE script by ID.
+        parameters:
+            - in: path
+              name: pk
+              required: true
+              schema:
+                  type: integer
+              description: ID of the NSE script to delete.
+        responses:
+            200:
+                description: NSE script deleted successfully.
+            404:
+                description: NSE script not found.
+        """
+        item = db.session.query(Nses).filter(Nses.id == pk).one_or_none()
+        if item is None:
+            return self.response_404()
+
+        file_manager = FileManager()
+        if item.filebody:
+            file_manager.delete_file(item.filebody)
+
+        db.session.delete(item)
+        db.session.commit()
+        return self.response(200, message=f"NSE '{item.name}' deleted")
+
+
 appbuilder.add_api(PublicTargetsApi)
 appbuilder.add_api(TargetsApi)
 appbuilder.add_api(Api)
+appbuilder.add_api(NsesApi)


### PR DESCRIPTION
Closes #172

## Summary

Adds a new `NsesApi(BaseApi)` class at `/api/v1/nses` that exposes full CRUD over NSE scripts, replacing the need to scrape the `/nsesview` HTML form.

| Method | Path | Action |
|--------|------|--------|
| GET | `/api/v1/nses/` | list all NSE scripts |
| POST | `/api/v1/nses/` | upload a new `.nse` file; upserts on name collision |
| GET | `/api/v1/nses/<pk>` | read a single script by ID |
| PUT | `/api/v1/nses/<pk>` | replace file content and/or rename in-place |
| DELETE | `/api/v1/nses/<pk>` | delete by ID |

All five endpoints follow the existing `@protect()` / `@safe` pattern used throughout `apis.py`.

## Implementation details

- **POST**: accepts `filebody` multipart field; validates `.nse` extension; computes SHA-256; upserts if a script with the same name already exists; uses `FileManager` for storage.
- **PUT**: accepts optional `filebody` and/or `name` form field (at least one required); validates extension; rejects SHA-256 hash collisions with *other* records; uses `FileManager` to delete old file and save the new one before committing.
- **DELETE**: looks up by ID, calls `FileManager.delete_file`, removes the DB row, returns a confirmation message.
- All responses return `{result: {id, name, hash}}` (or `{result: [...]}` for list).

## Test plan

- [ ] `GET /api/v1/nses/` returns list of all scripts
- [ ] `POST /api/v1/nses/` with a `.nse` file creates a new record and returns 201
- [ ] `POST /api/v1/nses/` with a duplicate name updates the existing record (200)
- [ ] `POST /api/v1/nses/` with a non-`.nse` file returns 400
- [ ] `POST /api/v1/nses/` with a duplicate SHA-256 (different name) returns 400
- [ ] `GET /api/v1/nses/<pk>` returns 200 + `{id, name, hash}` for existing script
- [ ] `GET /api/v1/nses/<pk>` returns 404 for unknown ID
- [ ] `PUT /api/v1/nses/<pk>` with new file replaces content and hash
- [ ] `PUT /api/v1/nses/<pk>` with new name renames the script
- [ ] `PUT /api/v1/nses/<pk>` with both file and name does both
- [ ] `PUT /api/v1/nses/<pk>` with no payload returns 400
- [ ] `PUT /api/v1/nses/<pk>` with a non-`.nse` file returns 400
- [ ] `PUT /api/v1/nses/<pk>` with a duplicate hash (different record) returns 400
- [ ] `PUT /api/v1/nses/<pk>` returns 404 for unknown ID
- [ ] `DELETE /api/v1/nses/<pk>` removes the record and file
- [ ] `DELETE /api/v1/nses/<pk>` returns 404 for unknown ID